### PR TITLE
Fix unit test compatibility with PHP 8

### DIFF
--- a/tests/Phug/FormatterTest.php
+++ b/tests/Phug/FormatterTest.php
@@ -1170,7 +1170,7 @@ class FormatterTest extends TestCase
         $document->appendChild($htmlEl = new MarkupElement('html'));
         $htmlEl->appendChild($bodyEl = new MarkupElement('body'));
         $bodyEl->appendChild(new ExpressionElement(
-            '12 / 0',
+            'trigger_error("Division by zero")',
             $node
         ));
         $php = $formatter->format($document);
@@ -1196,7 +1196,7 @@ class FormatterTest extends TestCase
             'debug' => true,
         ]);
         $helper = function () {
-            return 12 / 0;
+            trigger_error('Division by zero');
         };
         $node = new ExpressionNode(null, new SourceLocation(null, 7, 9));
         $document = new DocumentElement();
@@ -1340,7 +1340,7 @@ class FormatterTest extends TestCase
         $document->appendChild($htmlEl = new MarkupElement('html'));
         $htmlEl->appendChild($bodyEl = new MarkupElement('body'));
         $bodyEl->appendChild(new ExpressionElement(
-            '12 / 0',
+            'trigger_error("Division by zero")',
             $node
         ));
         $php = $formatter->format($document);

--- a/tests/Phug/RendererTest.php
+++ b/tests/Phug/RendererTest.php
@@ -468,7 +468,7 @@ class RendererTest extends AbstractRendererTest
             $message = null;
 
             try {
-                $renderer->render('div: p=12/0');
+                $renderer->render('div: p=trigger_error("Division by zero")');
             } catch (\Exception $error) {
                 $message = $error->getMessage();
             }
@@ -479,7 +479,7 @@ class RendererTest extends AbstractRendererTest
             );
 
             self::assertNotContains(
-                '12/0',
+                'trigger_error("Division'.'by'.'zero")',
                 str_replace(' ', '', $message)
             );
 
@@ -487,7 +487,7 @@ class RendererTest extends AbstractRendererTest
             $renderer->setOption('debug', true);
 
             try {
-                $renderer->render('div: p=12/0');
+                $renderer->render('div: p=trigger_error("Division by zero")');
             } catch (RendererException $error) {
                 $message = $error->getMessage();
             }
@@ -498,7 +498,7 @@ class RendererTest extends AbstractRendererTest
             );
 
             self::assertContains(
-                '12/0',
+                'trigger_error("Division'.'by'.'zero")',
                 str_replace(' ', '', $message)
             );
 
@@ -506,7 +506,7 @@ class RendererTest extends AbstractRendererTest
             $renderer->setOption('color_support', true);
 
             try {
-                $renderer->render('div: p=12/0');
+                $renderer->render('div: p=trigger_error("Division by zero")');
             } catch (RendererException $error) {
                 $message = $error->getMessage();
             }
@@ -517,7 +517,7 @@ class RendererTest extends AbstractRendererTest
             );
 
             self::assertContains(
-                "\033[43;30m>   1 | div: p\033[43;31m=\033[43;30m12/0\e[0m\n",
+                "\033[43;30m>   1 | div: p\033[43;31m=\033[43;30mtrigger_error(\"Division by zero\")\e[0m\n",
                 $message
             );
         }

--- a/tests/Phug/Util/SandBoxTest.php
+++ b/tests/Phug/Util/SandBoxTest.php
@@ -55,7 +55,7 @@ class SandBoxTest extends TestCase
     {
         $sandBox = new SandBox(function () {
             echo 'foo';
-            $a = trigger_error("Division by zero");
+            $a = trigger_error('Division by zero');
             echo 'bar';
 
             return $a;
@@ -89,11 +89,10 @@ class SandBoxTest extends TestCase
 
         self::assertInstanceOf(ErrorException::class, $sandBox->getThrowable());
 
-        error_reporting(E_ALL ^ E_NOTICE);
+        error_reporting(E_ALL ^ E_USER_NOTICE);
 
         $sandBox = new SandBox(function () {
-            $a = [];
-            $b = $a['foo'];
+            trigger_error('Undefined index');
         });
 
         self::assertNull($sandBox->getThrowable());
@@ -101,14 +100,13 @@ class SandBoxTest extends TestCase
         error_reporting(E_ALL);
 
         $sandBox = new SandBox(function () {
-            $a = [];
-            $b = $a['foo'];
+            trigger_error('Undefined index');
         }, function ($number, $message, $file, $line) {
             throw new ErrorException('interceptor', $number);
         });
 
         self::assertSame('interceptor', $sandBox->getThrowable()->getMessage());
-        self::assertSame(E_NOTICE, $sandBox->getThrowable()->getCode());
+        self::assertSame(E_USER_NOTICE, $sandBox->getThrowable()->getCode());
 
         error_reporting($level);
     }

--- a/tests/Phug/Util/SandBoxTest.php
+++ b/tests/Phug/Util/SandBoxTest.php
@@ -55,7 +55,7 @@ class SandBoxTest extends TestCase
     {
         $sandBox = new SandBox(function () {
             echo 'foo';
-            $a = 5 / 0;
+            $a = trigger_error("Division by zero");
             echo 'bar';
 
             return $a;
@@ -89,10 +89,7 @@ class SandBoxTest extends TestCase
 
         self::assertInstanceOf(ErrorException::class, $sandBox->getThrowable());
 
-        $undefinedOffsetSeverity = version_compare(PHP_VERSION, '8.0.0-dev', '<')
-            ? E_NOTICE
-            : E_WARNING;
-        error_reporting(E_ALL ^ $undefinedOffsetSeverity);
+        error_reporting(E_ALL ^ E_NOTICE);
 
         $sandBox = new SandBox(function () {
             $a = [];
@@ -111,7 +108,7 @@ class SandBoxTest extends TestCase
         });
 
         self::assertSame('interceptor', $sandBox->getThrowable()->getMessage());
-        self::assertSame($undefinedOffsetSeverity, $sandBox->getThrowable()->getCode());
+        self::assertSame(E_NOTICE, $sandBox->getThrowable()->getCode());
 
         error_reporting($level);
     }


### PR DESCRIPTION
Due to the division-by-zero severity requalification, test must be aligned to pass with PHP 8
https://wiki.php.net/rfc/engine_warnings.#division_by_zero