### PR TITLE
Add attribute_precedence option

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: ['5.5', '5.6', '7.0', '7.1', '7.2', '7.3', '7.4', '8.0', '8.1']
+        php: ['5.5', '5.6', '7.0', '7.1', '7.2', '7.3', '7.4', '8.0', '8.1', '8.2', '8.3']
         setup: ['lowest', 'stable', 'next']
 
     name: PHP ${{ matrix.php }} - ${{ matrix.setup }}

--- a/src/Phug/Ast/Ast/Node.php
+++ b/src/Phug/Ast/Ast/Node.php
@@ -370,7 +370,6 @@ class Node implements NodeInterface
         $level = $level ?: 0;
 
         foreach ($this->children as $child) {
-
             /** @var NodeInterface $child */
             if ($child->is($callback)) {
                 yield $child;

--- a/src/Phug/Compiler/Compiler/NodeCompiler/AssignmentNodeCompiler.php
+++ b/src/Phug/Compiler/Compiler/NodeCompiler/AssignmentNodeCompiler.php
@@ -8,7 +8,6 @@ use Phug\Formatter\ElementInterface;
 use Phug\Parser\Node\AssignmentNode;
 use Phug\Parser\Node\AttributeNode;
 use Phug\Parser\NodeInterface;
-use Phug\Util\AttributesStorage;
 use Phug\Util\OrderableInterface;
 use SplObjectStorage;
 

--- a/src/Phug/Compiler/Compiler/NodeCompiler/AssignmentNodeCompiler.php
+++ b/src/Phug/Compiler/Compiler/NodeCompiler/AssignmentNodeCompiler.php
@@ -8,6 +8,8 @@ use Phug\Formatter\ElementInterface;
 use Phug\Parser\Node\AssignmentNode;
 use Phug\Parser\Node\AttributeNode;
 use Phug\Parser\NodeInterface;
+use Phug\Util\AttributesStorage;
+use Phug\Util\OrderableInterface;
 use SplObjectStorage;
 
 class AssignmentNodeCompiler extends AbstractNodeCompiler
@@ -25,9 +27,16 @@ class AssignmentNodeCompiler extends AbstractNodeCompiler
          */
         $name = $node->getName();
         $attributes = new SplObjectStorage();
+
         foreach ($node->getAttributes() as $attribute) {
             /* @var AttributeNode $attribute */
-            $attributes->attach($this->getCompiler()->compileNode($attribute, $parent));
+            $attributeElement = $this->getCompiler()->compileNode($attribute, $parent);
+
+            if ($attribute instanceof OrderableInterface && $attributeElement instanceof OrderableInterface) {
+                $attributeElement->setOrder($attribute->getOrder());
+            }
+
+            $attributes->attach($attributeElement);
         }
 
         return new AssignmentElement($name, $attributes, null, $node);

--- a/src/Phug/Compiler/Compiler/NodeCompiler/AttributeNodeCompiler.php
+++ b/src/Phug/Compiler/Compiler/NodeCompiler/AttributeNodeCompiler.php
@@ -9,6 +9,7 @@ use Phug\Formatter\Element\TextElement;
 use Phug\Formatter\ElementInterface;
 use Phug\Parser\Node\AttributeNode;
 use Phug\Parser\NodeInterface;
+use Phug\Util\OrderableInterface;
 
 class AttributeNodeCompiler extends AbstractNodeCompiler
 {
@@ -71,6 +72,7 @@ class AttributeNodeCompiler extends AbstractNodeCompiler
         $name = $this->compileName($node);
         $value = $this->compileValue($node);
         $attribute = new AttributeElement($name, $value, $node);
+        $attribute->setOrder($node->getOrder());
         $attribute->setIsVariadic($node->isVariadic());
 
         return $attribute;

--- a/src/Phug/Compiler/Compiler/NodeCompiler/AttributeNodeCompiler.php
+++ b/src/Phug/Compiler/Compiler/NodeCompiler/AttributeNodeCompiler.php
@@ -9,7 +9,6 @@ use Phug\Formatter\Element\TextElement;
 use Phug\Formatter\ElementInterface;
 use Phug\Parser\Node\AttributeNode;
 use Phug\Parser\NodeInterface;
-use Phug\Util\OrderableInterface;
 
 class AttributeNodeCompiler extends AbstractNodeCompiler
 {

--- a/src/Phug/Compiler/Compiler/NodeCompiler/ElementNodeCompiler.php
+++ b/src/Phug/Compiler/Compiler/NodeCompiler/ElementNodeCompiler.php
@@ -9,6 +9,7 @@ use Phug\Formatter\ElementInterface;
 use Phug\Parser\Node\ElementNode;
 use Phug\Parser\Node\ExpressionNode;
 use Phug\Parser\NodeInterface;
+use Phug\Util\OrderableInterface;
 use SplObjectStorage;
 
 class ElementNodeCompiler extends AbstractNodeCompiler
@@ -35,6 +36,11 @@ class ElementNodeCompiler extends AbstractNodeCompiler
         $markup = new MarkupElement($name, $node->isAutoClosed(), $attributes, $node);
         foreach ($node->getAssignments() as $assignment) {
             $compiledAssignment = $compiler->compileNode($assignment, $parent);
+
+            if ($compiledAssignment instanceof OrderableInterface && $assignment instanceof OrderableInterface) {
+                $compiledAssignment->setOrder($assignment->getOrder());
+            }
+
             if ($compiledAssignment instanceof AssignmentElement) {
                 $markup->addAssignment($compiledAssignment);
             }

--- a/src/Phug/Compiler/Compiler/NodeCompilerInterface.php
+++ b/src/Phug/Compiler/Compiler/NodeCompilerInterface.php
@@ -11,7 +11,7 @@ use Phug\Parser\NodeInterface as ParserNodeInterface;
 interface NodeCompilerInterface
 {
     /**
-     * @param $nodeList
+     * @param                  $nodeList
      * @param ElementInterface $parent
      *
      * @return array

--- a/src/Phug/Formatter/Formatter/AbstractFormat.php
+++ b/src/Phug/Formatter/Formatter/AbstractFormat.php
@@ -233,7 +233,7 @@ abstract class AbstractFormat implements FormatInterface, OptionInterface
     /**
      * @param string|ElementInterface $element
      * @param bool                    $noDebug
-     * @param $element
+     * @param                         $element
      *
      * @return string
      */
@@ -460,13 +460,16 @@ abstract class AbstractFormat implements FormatInterface, OptionInterface
             return 'null';
         }
 
-        if ($value instanceof ExpressionElement &&
-            in_array(($code = strtolower($value->getValue())), ['true', 'false', 'null', 'undefined'])
-        ) {
-            return $code;
+        if ($value instanceof ExpressionElement) {
+            $code = strtolower($value->getValue());
+
+            if (in_array($code, ['true', 'false', 'null', 'undefined'])) {
+                return $code;
+            }
         }
 
         $code = $this->formatAssignmentValue($value);
+
         if ($value instanceof ExpressionElement && $value->isEscaped()) {
             return $this->exportHelper('array_escape', [$formattedName, $code]);
         }

--- a/src/Phug/Formatter/Formatter/AssignmentContainerInterface.php
+++ b/src/Phug/Formatter/Formatter/AssignmentContainerInterface.php
@@ -3,8 +3,9 @@
 namespace Phug\Formatter;
 
 use Phug\Formatter\Element\AssignmentElement;
+use Phug\Util\AttributesOrderInterface;
 
-interface AssignmentContainerInterface extends ElementInterface
+interface AssignmentContainerInterface extends ElementInterface, AttributesOrderInterface
 {
     public function getName();
 

--- a/src/Phug/Formatter/Formatter/Element/AbstractAssignmentContainerElement.php
+++ b/src/Phug/Formatter/Formatter/Element/AbstractAssignmentContainerElement.php
@@ -4,10 +4,16 @@ namespace Phug\Formatter\Element;
 
 use Phug\Formatter\AbstractElement;
 use Phug\Formatter\AssignmentContainerInterface;
+use Phug\Util\Partial\AttributesOrderTrait;
 use SplObjectStorage;
 
 abstract class AbstractAssignmentContainerElement extends AbstractElement implements AssignmentContainerInterface
 {
+    use AttributesOrderTrait;
+
+    /**
+     * @var SplObjectStorage<AssignmentElement>
+     */
     private $assignments;
 
     /**
@@ -19,6 +25,10 @@ abstract class AbstractAssignmentContainerElement extends AbstractElement implem
      */
     public function addAssignment(AssignmentElement $element)
     {
+        if ($element->getOrder() === null) {
+            $element->setOrder($this->getNextAttributeIndex());
+        }
+
         $element->setContainer($this);
         $this->getAssignments()->attach($element);
 
@@ -42,7 +52,7 @@ abstract class AbstractAssignmentContainerElement extends AbstractElement implem
     /**
      * Return markup assignments list.
      *
-     * @return SplObjectStorage[AssignmentElement]
+     * @return SplObjectStorage<AssignmentElement>
      */
     public function getAssignments()
     {

--- a/src/Phug/Formatter/Formatter/Element/AssignmentElement.php
+++ b/src/Phug/Formatter/Formatter/Element/AssignmentElement.php
@@ -7,27 +7,31 @@ use Phug\Formatter\AbstractElement;
 use Phug\Formatter\AssignmentContainerInterface;
 use Phug\Parser\NodeInterface as ParserNode;
 use Phug\Util\AttributesInterface;
+use Phug\Util\OrderableInterface;
 use Phug\Util\Partial\AttributeTrait;
 use Phug\Util\Partial\NameTrait;
+use Phug\Util\Partial\OrderTrait;
+use SplObjectStorage;
 
-class AssignmentElement extends AbstractElement implements AttributesInterface
+class AssignmentElement extends AbstractElement implements AttributesInterface, OrderableInterface
 {
     use AttributeTrait;
     use NameTrait;
+    use OrderTrait;
 
     /**
      * AssignmentElement constructor.
      *
      * @param string                            $name
-     * @param \SplObjectStorage|null            $attributes
-     * @param AssignmentContainerInterface|null $markup
+     * @param SplObjectStorage|null             $attributes
+     * @param AssignmentContainerInterface|null $container
      * @param ParserNode|null                   $originNode
      * @param NodeInterface|null                $parent
      * @param array|null                        $children
      */
     public function __construct(
         $name,
-        \SplObjectStorage $attributes = null,
+        SplObjectStorage $attributes = null,
         AssignmentContainerInterface $container = null,
         ParserNode $originNode = null,
         NodeInterface $parent = null,

--- a/src/Phug/Formatter/Formatter/Element/AttributeElement.php
+++ b/src/Phug/Formatter/Formatter/Element/AttributeElement.php
@@ -4,12 +4,15 @@ namespace Phug\Formatter\Element;
 
 use Phug\Ast\NodeInterface;
 use Phug\Parser\NodeInterface as ParserNode;
+use Phug\Util\OrderableInterface;
 use Phug\Util\Partial\NameTrait;
+use Phug\Util\Partial\OrderTrait;
 use Phug\Util\Partial\VariadicTrait;
 
-class AttributeElement extends AbstractValueElement
+class AttributeElement extends AbstractValueElement implements OrderableInterface
 {
     use NameTrait;
+    use OrderTrait;
     use VariadicTrait;
 
     /**

--- a/src/Phug/Formatter/Formatter/Element/MarkupElement.php
+++ b/src/Phug/Formatter/Formatter/Element/MarkupElement.php
@@ -7,6 +7,7 @@ use Phug\Parser\NodeInterface as ParserNode;
 use Phug\Util\AttributesInterface;
 use Phug\Util\Partial\AttributeTrait;
 use Phug\Util\Partial\NameTrait;
+use SplObjectStorage;
 
 class MarkupElement extends AbstractMarkupElement implements AttributesInterface
 {
@@ -21,17 +22,17 @@ class MarkupElement extends AbstractMarkupElement implements AttributesInterface
     /**
      * MarkupElement constructor.
      *
-     * @param string                 $name
-     * @param bool                   $autoClosed
-     * @param \SplObjectStorage|null $attributes
-     * @param ParserNode|null        $originNode
-     * @param NodeInterface|null     $parent
-     * @param array|null             $children
+     * @param string                $name
+     * @param bool                  $autoClosed
+     * @param SplObjectStorage|null $attributes
+     * @param ParserNode|null       $originNode
+     * @param NodeInterface|null    $parent
+     * @param array|null            $children
      */
     public function __construct(
         $name,
         $autoClosed = false,
-        \SplObjectStorage $attributes = null,
+        SplObjectStorage $attributes = null,
         ParserNode $originNode = null,
         NodeInterface $parent = null,
         array $children = null

--- a/src/Phug/Formatter/Formatter/Format/XmlFormat.php
+++ b/src/Phug/Formatter/Formatter/Format/XmlFormat.php
@@ -2,7 +2,9 @@
 
 namespace Phug\Formatter\Format;
 
+use Closure;
 use Generator;
+use InvalidArgumentException;
 use Phug\Formatter;
 use Phug\Formatter\AbstractFormat;
 use Phug\Formatter\AssignmentContainerInterface;
@@ -20,6 +22,7 @@ use Phug\Formatter\Partial\AssignmentHelpersTrait;
 use Phug\FormatterException;
 use Phug\Util\AttributesInterface;
 use Phug\Util\Joiner;
+use Phug\Util\OrderedValue;
 use SplObjectStorage;
 
 class XmlFormat extends AbstractFormat
@@ -268,17 +271,65 @@ class XmlFormat extends AbstractFormat
 
         /* @var MarkupElement $markup */
         $markup = $element->getContainer();
+        $attributeOrder = $this->hasOption('attribute_precedence')
+            ? $this->getOption('attribute_precedence')
+            : 'assignment';
 
-        $arguments = $markup instanceof AssignmentContainerInterface
-            ? $this->formatAttributeAssignments($markup)
-            : [];
+        switch ($attributeOrder) {
+            case 'assignment':
+            case 'assignments':
+                $arguments = array_merge(
+                    $markup instanceof AttributesInterface
+                        ? $this->formatMarkupAttributes($markup)
+                        : [],
+                    $markup instanceof AssignmentContainerInterface
+                        ? $this->formatAttributeAssignments($markup)
+                        : []
+                );
+                break;
 
-        $arguments = array_merge(
-            $markup instanceof AttributesInterface
-                ? $this->formatMarkupAttributes($markup)
-                : [],
-            $arguments
-        );
+            case 'attribute':
+            case 'attributes':
+                $arguments = array_merge(
+                    $markup instanceof AssignmentContainerInterface
+                        ? $this->formatAttributeAssignments($markup)
+                        : [],
+                    $markup instanceof AttributesInterface
+                        ? $this->formatMarkupAttributes($markup)
+                        : []
+                );
+                break;
+
+            case 'left':
+                $arguments = $this->getSortedAttributes($markup, static function (OrderedValue $a, OrderedValue $b) {
+                    return $b->getOrder() - $a->getOrder();
+                });
+                break;
+
+            case 'right':
+                $arguments = $this->getSortedAttributes($markup, static function (OrderedValue $a, OrderedValue $b) {
+                    return $a->getOrder() - $b->getOrder();
+                });
+                break;
+
+            default:
+                if (!is_callable($attributeOrder)) {
+                    throw new InvalidArgumentException(
+                        'Option attribute_precedence must be "assignment" (default), "attribute", "left", "right" or a callable.'
+                    );
+                }
+
+                $arguments = array_map(static function ($argument) {
+                    return $argument instanceof OrderedValue ? $argument->getValue() : $argument;
+                }, $attributeOrder(
+                    $markup instanceof AssignmentContainerInterface
+                        ? $this->formatOrderedAttributeAssignments($markup)
+                        : [],
+                    $markup instanceof AttributesInterface
+                        ? $this->formatOrderedMarkupAttributes($markup)
+                        : []
+                ));
+        }
 
         foreach ($markup->getAssignments() as $assignment) {
             /* @var AssignmentElement $assignment */
@@ -303,13 +354,7 @@ class XmlFormat extends AbstractFormat
         $arguments = [];
 
         foreach ($this->yieldAssignmentAttributes($markup) as $attribute) {
-            $checked = method_exists($attribute, 'isChecked') && $attribute->isChecked();
-
-            while (method_exists($attribute, 'getValue')) {
-                $attribute = $attribute->getValue();
-            }
-
-            $arguments[] = $this->formatCode($attribute, $checked);
+            $arguments[] = $this->formatInnerCodeValue($attribute);
         }
 
         return $arguments;
@@ -318,7 +363,39 @@ class XmlFormat extends AbstractFormat
     /**
      * @param AssignmentContainerInterface $markup
      *
-     * @return Generator|AbstractValueElement[]
+     * @return list<OrderedValue<string>>
+     */
+    protected function formatOrderedAttributeAssignments(AssignmentContainerInterface $markup)
+    {
+        $arguments = [];
+
+        foreach ($this->yieldAssignmentOrderedAttributes($markup) as $attribute => $order) {
+            $arguments[] = new OrderedValue($this->formatInnerCodeValue($attribute), $order);
+        }
+
+        return $arguments;
+    }
+
+    /**
+     * @param AbstractValueElement|mixed $value
+     *
+     * @return string
+     */
+    protected function formatInnerCodeValue($value)
+    {
+        $checked = method_exists($value, 'isChecked') && $value->isChecked();
+
+        while (method_exists($value, 'getValue')) {
+            $value = $value->getValue();
+        }
+
+        return $this->formatCode($value, $checked);
+    }
+
+    /**
+     * @param AssignmentContainerInterface $markup
+     *
+     * @return Generator<AbstractValueElement>
      */
     protected function yieldAssignmentAttributes(AssignmentContainerInterface $markup)
     {
@@ -334,9 +411,27 @@ class XmlFormat extends AbstractFormat
     }
 
     /**
+     * @param AssignmentContainerInterface $markup
+     *
+     * @return Generator<AbstractValueElement, int|null>
+     */
+    protected function yieldAssignmentOrderedAttributes(AssignmentContainerInterface $markup)
+    {
+        foreach ($markup->getAssignmentsByName('attributes') as $attributesAssignment) {
+            /* @var AssignmentElement $attributesAssignment */
+            foreach ($attributesAssignment->getAttributes() as $attribute) {
+                /* @var AbstractValueElement $attribute */
+                yield $attribute => $attributesAssignment->getOrder();
+            }
+
+            $markup->removedAssignment($attributesAssignment);
+        }
+    }
+
+    /**
      * @param AttributesInterface $markup
      *
-     * @return array<string>
+     * @return list<string>
      */
     protected function formatMarkupAttributes(AttributesInterface $markup)
     {
@@ -346,6 +441,26 @@ class XmlFormat extends AbstractFormat
         foreach ($attributes as $attribute) {
             /* @var AttributeElement $attribute */
             $arguments[] = $this->formatAttributeAsArrayItem($attribute);
+        }
+
+        $attributes->removeAll($attributes);
+
+        return $arguments;
+    }
+
+    /**
+     * @param AttributesInterface $markup
+     *
+     * @return list<OrderedValue<string>>
+     */
+    protected function formatOrderedMarkupAttributes(AttributesInterface $markup)
+    {
+        $arguments = [];
+        $attributes = $markup->getAttributes();
+
+        foreach ($attributes as $attribute) {
+            /* @var AttributeElement $attribute */
+            $arguments[] = new OrderedValue($this->formatAttributeAsArrayItem($attribute), $attribute->getOrder());
         }
 
         $attributes->removeAll($attributes);
@@ -440,5 +555,28 @@ class XmlFormat extends AbstractFormat
         return !$element->isAutoClosed() && $this->isBlockTag($element)
             ? $this->getIndent().$tag.$this->getNewLine()
             : $tag;
+    }
+
+    /**
+     * @param AssignmentContainerInterface|AttributesInterface|mixed $markup
+     * @param Closure(OrderedValue, OrderedValue): int $sorter
+     *
+     * @return list<string>
+     */
+    private function getSortedAttributes($markup, Closure $sorter)
+    {
+        $arguments = array_merge(
+            $markup instanceof AssignmentContainerInterface
+                ? $this->formatOrderedAttributeAssignments($markup)
+                : [],
+            $markup instanceof AttributesInterface
+                ? $this->formatOrderedMarkupAttributes($markup)
+                : []
+        );
+        usort($arguments, $sorter);
+
+        return array_map(static function (OrderedValue $value) {
+            return $value->getValue();
+        }, $arguments);
     }
 }

--- a/src/Phug/Formatter/Formatter/Format/XmlFormat.php
+++ b/src/Phug/Formatter/Formatter/Format/XmlFormat.php
@@ -315,7 +315,8 @@ class XmlFormat extends AbstractFormat
             default:
                 if (!is_callable($attributeOrder)) {
                     throw new InvalidArgumentException(
-                        'Option attribute_precedence must be "assignment" (default), "attribute", "left", "right" or a callable.'
+                        'Option attribute_precedence must be '.
+                        '"assignment" (default), "attribute", "left", "right" or a callable.'
                     );
                 }
 
@@ -559,7 +560,7 @@ class XmlFormat extends AbstractFormat
 
     /**
      * @param AssignmentContainerInterface|AttributesInterface|mixed $markup
-     * @param Closure(OrderedValue, OrderedValue): int $sorter
+     * @param Closure(OrderedValue, OrderedValue): int               $sorter
      *
      * @return list<string>
      */

--- a/src/Phug/Formatter/Formatter/Partial/AssignmentHelpersTrait.php
+++ b/src/Phug/Formatter/Formatter/Partial/AssignmentHelpersTrait.php
@@ -37,7 +37,7 @@ trait AssignmentHelpersTrait
                 return function (&$attributes, $name, $value) use ($attributeAssignments) {
                     if (isset($name) && $name !== '') {
                         $result = $attributeAssignments($attributes, $name, $value);
-                        if (($result !== null && $result !== false && ($result !== '' || $name !== 'class'))) {
+                        if ($result !== null && $result !== false && ($result !== '' || $name !== 'class')) {
                             $attributes[$name] = $result;
                         }
                     }

--- a/src/Phug/Lexer/Lexer/State.php
+++ b/src/Phug/Lexer/Lexer/State.php
@@ -241,7 +241,6 @@ class State implements OptionInterface
         $scanners = $this->filterScanners($scanners);
 
         foreach ($scanners as $scanner) {
-
             /** @var ScannerInterface $scanner */
             $success = false;
             foreach ($scanner->scan($this, $options) as $token) {
@@ -267,7 +266,7 @@ class State implements OptionInterface
      * If the second argument is true, it will throw an exception if none of the scanners
      * produced any valid tokens. The reading also stops when the end of the input as been reached.
      *
-     * @param $scanners
+     * @param      $scanners
      * @param bool $required
      *
      * @throws LexerException
@@ -346,9 +345,9 @@ class State implements OptionInterface
      * in scanners as you can simply return it's value without having to check for it to be null.
      *
      *
-     * @param $className
-     * @param $pattern
-     * @param null $modifiers
+     * @param class-string $className
+     * @param string       $pattern
+     * @param string|null  $modifiers
      *
      * @return iterable
      */

--- a/src/Phug/Parser/Parser.php
+++ b/src/Phug/Parser/Parser.php
@@ -330,8 +330,8 @@ class Parser implements ModuleContainerInterface
 
         foreach ($expandingNodes as $expandingNode) {
             $current = $expandingNode;
-            while ($outerNode = $expandingNode->getOuterNode()) {
 
+            while ($outerNode = $expandingNode->getOuterNode()) {
                 /** @var NodeInterface $expandedNode */
                 $expandedNode = $outerNode;
                 $current->setOuterNode(null);

--- a/src/Phug/Parser/Parser/Event/NodeEvent.php
+++ b/src/Phug/Parser/Parser/Event/NodeEvent.php
@@ -4,6 +4,7 @@ namespace Phug\Parser\Event;
 
 use Phug\Event;
 use Phug\Parser\NodeInterface;
+use Phug\ParserEvent;
 
 class NodeEvent extends Event
 {
@@ -12,8 +13,8 @@ class NodeEvent extends Event
     /**
      * NodeEvent constructor.
      *
-     * @param $name
-     * @param NodeInterface $node
+     * @param ParserEvent::* $name
+     * @param NodeInterface  $node
      */
     public function __construct($name, NodeInterface $node)
     {

--- a/src/Phug/Parser/Parser/Node/AssignmentNode.php
+++ b/src/Phug/Parser/Parser/Node/AssignmentNode.php
@@ -4,11 +4,14 @@ namespace Phug\Parser\Node;
 
 use Phug\Parser\Node;
 use Phug\Util\AttributesInterface;
+use Phug\Util\OrderableInterface;
 use Phug\Util\Partial\AttributeTrait;
 use Phug\Util\Partial\NameTrait;
+use Phug\Util\Partial\OrderTrait;
 
-class AssignmentNode extends Node implements AttributesInterface
+class AssignmentNode extends Node implements AttributesInterface, OrderableInterface
 {
     use NameTrait;
     use AttributeTrait;
+    use OrderTrait;
 }

--- a/src/Phug/Parser/Parser/Node/AttributeNode.php
+++ b/src/Phug/Parser/Parser/Node/AttributeNode.php
@@ -3,17 +3,20 @@
 namespace Phug\Parser\Node;
 
 use Phug\Parser\Node;
+use Phug\Util\OrderableInterface;
 use Phug\Util\Partial\CheckTrait;
 use Phug\Util\Partial\EscapeTrait;
 use Phug\Util\Partial\NameTrait;
+use Phug\Util\Partial\OrderTrait;
 use Phug\Util\Partial\ValueTrait;
 use Phug\Util\Partial\VariadicTrait;
 
-class AttributeNode extends Node
+class AttributeNode extends Node implements OrderableInterface
 {
     use NameTrait;
     use ValueTrait;
     use EscapeTrait;
     use CheckTrait;
     use VariadicTrait;
+    use OrderTrait;
 }

--- a/src/Phug/Parser/Parser/Node/ElementNode.php
+++ b/src/Phug/Parser/Parser/Node/ElementNode.php
@@ -4,15 +4,18 @@ namespace Phug\Parser\Node;
 
 use Phug\Parser\Node;
 use Phug\Util\AttributesInterface;
+use Phug\Util\AttributesOrderInterface;
 use Phug\Util\Partial\AssignmentTrait;
+use Phug\Util\Partial\AttributesOrderTrait;
 use Phug\Util\Partial\AttributeTrait;
 use Phug\Util\Partial\NameTrait;
 
-class ElementNode extends Node implements AttributesInterface
+class ElementNode extends Node implements AttributesInterface, AttributesOrderInterface
 {
     use NameTrait;
     use AttributeTrait;
     use AssignmentTrait;
+    use AttributesOrderTrait;
 
     /**
      * @var bool

--- a/src/Phug/Parser/Parser/Node/MixinCallNode.php
+++ b/src/Phug/Parser/Parser/Node/MixinCallNode.php
@@ -4,15 +4,18 @@ namespace Phug\Parser\Node;
 
 use Phug\Parser\Node;
 use Phug\Util\AttributesInterface;
+use Phug\Util\AttributesOrderInterface;
 use Phug\Util\Partial\AssignmentTrait;
+use Phug\Util\Partial\AttributesOrderTrait;
 use Phug\Util\Partial\AttributeTrait;
 use Phug\Util\Partial\NameTrait;
 
-class MixinCallNode extends Node implements AttributesInterface
+class MixinCallNode extends Node implements AttributesInterface, AttributesOrderInterface
 {
     use NameTrait;
     use AttributeTrait;
     use AssignmentTrait;
+    use AttributesOrderTrait;
 
     /**
      * @var bool

--- a/src/Phug/Parser/Parser/Node/MixinNode.php
+++ b/src/Phug/Parser/Parser/Node/MixinNode.php
@@ -4,13 +4,16 @@ namespace Phug\Parser\Node;
 
 use Phug\Parser\Node;
 use Phug\Util\AttributesInterface;
+use Phug\Util\AttributesOrderInterface;
 use Phug\Util\Partial\AssignmentTrait;
+use Phug\Util\Partial\AttributesOrderTrait;
 use Phug\Util\Partial\AttributeTrait;
 use Phug\Util\Partial\NameTrait;
 
-class MixinNode extends Node implements AttributesInterface
+class MixinNode extends Node implements AttributesInterface, AttributesOrderInterface
 {
     use NameTrait;
     use AttributeTrait;
     use AssignmentTrait;
+    use AttributesOrderTrait;
 }

--- a/src/Phug/Parser/Parser/TokenHandler/AssignmentTokenHandler.php
+++ b/src/Phug/Parser/Parser/TokenHandler/AssignmentTokenHandler.php
@@ -39,6 +39,7 @@ class AssignmentTokenHandler implements TokenHandlerInterface
 
         /** @var ElementNode|MixinCallNode $current */
         $current = $state->getCurrentNode();
+        $node->setOrder($current->getNextAttributeIndex());
         $current->getAssignments()->attach($node);
 
         if ($state->expectNext([AttributeStartToken::class])) {

--- a/src/Phug/Parser/Parser/TokenHandler/AttributeTokenHandler.php
+++ b/src/Phug/Parser/Parser/TokenHandler/AttributeTokenHandler.php
@@ -10,6 +10,8 @@ use Phug\Parser\Node\ElementNode;
 use Phug\Parser\Node\MixinCallNode;
 use Phug\Parser\State;
 use Phug\Parser\TokenHandlerInterface;
+use Phug\Util\AttributesOrderInterface;
+use Phug\Util\OrderableInterface;
 
 class AttributeTokenHandler implements TokenHandlerInterface
 {
@@ -46,8 +48,15 @@ class AttributeTokenHandler implements TokenHandlerInterface
             }
         }
 
-        /** @var ElementNode|MixinCallNode $current */
+        /** @var ElementNode|MixinCallNode|AssignmentNode $current */
         $current = $state->getCurrentNode();
+
+        if ($current instanceof AttributesOrderInterface) {
+            $node->setOrder($current->getNextAttributeIndex());
+        } elseif ($current instanceof OrderableInterface) {
+            $node->setOrder($current->getOrder());
+        }
+
         $current->getAttributes()->attach($node);
     }
 }

--- a/src/Phug/Phug/Phug/Cli.php
+++ b/src/Phug/Phug/Phug/Cli.php
@@ -152,21 +152,21 @@ class Cli
     {
         return preg_replace_callback('/[A-Z]/', function ($match) {
             return '-'.strtolower($match[0]);
-        }, $string);
+        }, (string) $string);
     }
 
     protected function convertToCamelCase($string)
     {
         return preg_replace_callback('/-([a-z])/', function ($match) {
             return strtoupper($match[1]);
-        }, $string);
+        }, (string) $string);
     }
 
     protected function execute($facade, $method, $arguments, $outputFile)
     {
         $callable = [$facade, $method];
         $arguments = array_map(function ($argument) {
-            return in_array(substr($argument, 0, 1), ['[', '{'])
+            return in_array(substr((string) $argument, 0, 1), ['[', '{'])
                 ? json_decode($argument, true)
                 : $argument;
         }, $arguments);
@@ -206,7 +206,7 @@ class Cli
 
     protected function getNamedArgumentByEqualOperator(array &$arguments, $index, $name)
     {
-        if (preg_match('/^'.preg_quote($name).'=(.*)$/', $arguments[$index], $match)) {
+        if (preg_match('/^'.preg_quote($name).'=(.*)$/', (string) $arguments[$index], $match)) {
             array_splice($arguments, $index, 1);
 
             return $match[1];

--- a/src/Phug/Reader/Reader.php
+++ b/src/Phug/Reader/Reader.php
@@ -313,9 +313,9 @@ class Reader
      *
      * Notice that ^ is automatically prepended to the pattern.
      *
-     * @param string $pattern         the regular expression without slashes or modifiers.
-     * @param string $modifiers       the modifiers for the regular expression.
-     * @param string $ignoredSuffixes characters that are scanned, but don't end up in the consume length.
+     * @param string      $pattern         the regular expression without slashes or modifiers.
+     * @param string|null $modifiers       the modifiers for the regular expression.
+     * @param string|null $ignoredSuffixes characters that are scanned, but don't end up in the consume length.
      *
      * @throws ReaderException
      *

--- a/src/Phug/Renderer/Renderer/Adapter/Stream/Template.php
+++ b/src/Phug/Renderer/Renderer/Adapter/Stream/Template.php
@@ -20,6 +20,11 @@ class Template
     private $data = '';
 
     /**
+     * @var mixed
+     */
+    public $context;
+
+    /**
      * @param $path
      *
      * @return bool

--- a/src/Phug/Renderer/Renderer/CacheInterface.php
+++ b/src/Phug/Renderer/Renderer/CacheInterface.php
@@ -11,7 +11,7 @@ interface CacheInterface
     /**
      * Return the cached file path after cache optional process.
      *
-     * @param $path
+     * @param string   $path
      * @param string   $input    pug input
      * @param callable $rendered method to compile the source into PHP
      * @param bool     $success

--- a/src/Phug/Renderer/Renderer/Partial/Debug/DebuggerTrait.php
+++ b/src/Phug/Renderer/Renderer/Partial/Debug/DebuggerTrait.php
@@ -180,6 +180,7 @@ trait DebuggerTrait
 
     /**
      * @return bool
+     *
      * @codeCoverageIgnore
      */
     private function hasColorSupport()
@@ -200,6 +201,7 @@ trait DebuggerTrait
 
     /**
      * @return bool
+     *
      * @codeCoverageIgnore
      */
     private function hasStdOutVt100Support()
@@ -211,6 +213,7 @@ trait DebuggerTrait
 
     /**
      * @return bool
+     *
      * @codeCoverageIgnore
      */
     private function isStdOutATTY()

--- a/src/Phug/Renderer/Renderer/Profiler/LinkDump.php
+++ b/src/Phug/Renderer/Renderer/Profiler/LinkDump.php
@@ -33,11 +33,11 @@ class LinkDump
         foreach ([
             ['current', EndLexEvent::class, 'lexing', [
                 'background' => '#7200c4',
-                'color' => 'white',
+                'color'      => 'white',
             ]],
             ['current', HtmlEvent::class, 'rendering', [
                 'background' => '#648481',
-                'color' => 'white',
+                'color'      => 'white',
             ]],
             ['previous', CompileEvent::class, '%s', [
                 'background' => '#ffff78',

--- a/src/Phug/Util/Util/AttributesOrderInterface.php
+++ b/src/Phug/Util/Util/AttributesOrderInterface.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Phug\Util;
+
+/**
+ * Interface AttributesOrderInterface.
+ *
+ * Allow objects that have attributes to remember of the order in which attributes and assignments
+ * were added to them.
+ */
+interface AttributesOrderInterface
+{
+    /**
+     * @return int
+     */
+    public function getNextAttributeIndex();
+}

--- a/src/Phug/Util/Util/AttributesStorage.php
+++ b/src/Phug/Util/Util/AttributesStorage.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Phug\Util;
+
+use ReturnTypeWillChange;
+use SplObjectStorage;
+
+class AttributesStorage extends SplObjectStorage
+{
+    /** @var mixed */
+    private $holder;
+
+    public function __construct($holder)
+    {
+        $this->holder = $holder;
+    }
+
+    #[ReturnTypeWillChange]
+    public function attach($object, $info = null)
+    {
+        if (
+            $object instanceof OrderableInterface &&
+            $object->getOrder() === null &&
+            $this->holder instanceof AttributesOrderInterface
+        ) {
+            $object->setOrder($this->holder->getNextAttributeIndex());
+        }
+
+        parent::attach($object, $info);
+    }
+
+    #[ReturnTypeWillChange]
+    public function addAll($storage)
+    {
+        if ($storage && $this->holder instanceof AttributesOrderInterface) {
+            foreach ($storage as $element) {
+                if ($element instanceof OrderableInterface && $element->getOrder() === null) {
+                    $element->setOrder($this->holder->getNextAttributeIndex());
+                }
+            }
+        }
+
+        parent::addAll($storage);
+    }
+}

--- a/src/Phug/Util/Util/AttributesStorage.php
+++ b/src/Phug/Util/Util/AttributesStorage.php
@@ -18,8 +18,7 @@ class AttributesStorage extends SplObjectStorage
     #[ReturnTypeWillChange]
     public function attach($object, $info = null)
     {
-        if (
-            $object instanceof OrderableInterface &&
+        if ($object instanceof OrderableInterface &&
             $object->getOrder() === null &&
             $this->holder instanceof AttributesOrderInterface
         ) {

--- a/src/Phug/Util/Util/OrderableInterface.php
+++ b/src/Phug/Util/Util/OrderableInterface.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Phug\Util;
+
+/**
+ * Interface OrderableInterface.
+ *
+ * Allow objects to have an order index which allow, when compared to others in a list,
+ * to know if they were added earlier or later.
+ */
+interface OrderableInterface
+{
+    /**
+     * @return int|null
+     */
+    public function getOrder();
+
+    /**
+     * @param int|null $order
+     */
+    public function setOrder($order);
+}

--- a/src/Phug/Util/Util/OrderedValue.php
+++ b/src/Phug/Util/Util/OrderedValue.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Phug\Util;
+
+use Phug\Util\Partial\OrderTrait;
+use Phug\Util\Partial\ValueTrait;
+
+/**
+ * Class OrderedValue.
+ *
+ * @template T
+ * @template-implements ValueTrait<T>
+ */
+class OrderedValue implements OrderableInterface
+{
+    use ValueTrait;
+    use OrderTrait;
+
+    public function __construct($value, $order)
+    {
+        $this->value = $value;
+        $this->order = $order;
+    }
+}

--- a/src/Phug/Util/Util/OrderedValue.php
+++ b/src/Phug/Util/Util/OrderedValue.php
@@ -9,6 +9,7 @@ use Phug\Util\Partial\ValueTrait;
  * Class OrderedValue.
  *
  * @template T
+ *
  * @template-implements ValueTrait<T>
  */
 class OrderedValue implements OrderableInterface

--- a/src/Phug/Util/Util/Partial/AttributeTrait.php
+++ b/src/Phug/Util/Util/Partial/AttributeTrait.php
@@ -2,6 +2,7 @@
 
 namespace Phug\Util\Partial;
 
+use Phug\Util\AttributesStorage;
 use SplObjectStorage;
 
 /**
@@ -20,7 +21,7 @@ trait AttributeTrait
     public function getAttributes()
     {
         if (!$this->attributes) {
-            $this->attributes = new SplObjectStorage();
+            $this->attributes = new AttributesStorage($this);
         }
 
         return $this->attributes;

--- a/src/Phug/Util/Util/Partial/AttributesOrderTrait.php
+++ b/src/Phug/Util/Util/Partial/AttributesOrderTrait.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Phug\Util\Partial;
+
+trait AttributesOrderTrait
+{
+    /**
+     * @var int
+     */
+    protected $attributeIndex = 0;
+
+    /**
+     * @return int
+     */
+    public function getNextAttributeIndex()
+    {
+        return $this->attributeIndex++;
+    }
+}

--- a/src/Phug/Util/Util/Partial/OrderTrait.php
+++ b/src/Phug/Util/Util/Partial/OrderTrait.php
@@ -2,10 +2,6 @@
 
 namespace Phug\Util\Partial;
 
-use ArrayAccess;
-use ArrayObject;
-use Phug\Util\Collection;
-
 trait OrderTrait
 {
     /**

--- a/src/Phug/Util/Util/Partial/OrderTrait.php
+++ b/src/Phug/Util/Util/Partial/OrderTrait.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Phug\Util\Partial;
+
+use ArrayAccess;
+use ArrayObject;
+use Phug\Util\Collection;
+
+trait OrderTrait
+{
+    /**
+     * @var int|null
+     */
+    private $order = null;
+
+    /**
+     * @return int|null
+     */
+    public function getOrder()
+    {
+        return $this->order;
+    }
+
+    /**
+     * @param int|null $order
+     */
+    public function setOrder($order)
+    {
+        $this->order = $order;
+    }
+}

--- a/src/Phug/Util/Util/Partial/ValueTrait.php
+++ b/src/Phug/Util/Util/Partial/ValueTrait.php
@@ -4,18 +4,20 @@ namespace Phug\Util\Partial;
 
 /**
  * Class ValueTrait.
+ *
+ * @template T of mixed
  */
 trait ValueTrait
 {
     use StaticMemberTrait;
 
     /**
-     * @var mixed
+     * @var T
      */
     private $value = null;
 
     /**
-     * @return mixed
+     * @return T
      */
     public function getValue()
     {
@@ -31,7 +33,7 @@ trait ValueTrait
     }
 
     /**
-     * @param mixed $value
+     * @param T $value
      *
      * @return $this
      */

--- a/src/Phug/Util/Util/TestCase.php
+++ b/src/Phug/Util/Util/TestCase.php
@@ -6,6 +6,7 @@ use PHPUnit\Framework\TestCase as PHPUnitTestCase;
 use Phug\CompatibilityUtil\TestCaseTypeBase;
 use ReflectionMethod;
 
+// @codeCoverageIgnoreStart
 if (!class_exists(TestCaseTypeBase::class)) {
     $setUp = @new ReflectionMethod(PHPUnitTestCase::class, 'setUp');
     $testCaseInitialization = true;
@@ -16,6 +17,7 @@ if (!class_exists(TestCaseTypeBase::class)) {
 
     unset($testCaseInitialization);
 }
+// @codeCoverageIgnoreEnd
 
 class TestCase extends TestCaseTypeBase
 {

--- a/tests/Phug/AbstractCompilerTest.php
+++ b/tests/Phug/AbstractCompilerTest.php
@@ -78,7 +78,6 @@ abstract class AbstractCompilerTest extends TestCase
         });
 
         $compiler->attach(CompilerEvent::OUTPUT, function (Compiler\Event\OutputEvent $event) use ($compiler) {
-
             /** @var JsPhpize $jsPhpize */
             $jsPhpize = $compiler->getOption('jsphpize_engine');
             $dependencies = $jsPhpize->compileDependencies();

--- a/tests/Phug/AbstractCompilerTest.php
+++ b/tests/Phug/AbstractCompilerTest.php
@@ -6,14 +6,12 @@ use Exception;
 use JsPhpize\JsPhpize;
 use Phug\Compiler;
 use Phug\CompilerEvent;
+use Phug\Test\Utils\AssertRender;
 use Phug\Util\TestCase;
 
 abstract class AbstractCompilerTest extends TestCase
 {
-    /**
-     * @var Compiler
-     */
-    protected $compiler;
+    use AssertRender;
 
     protected function expectMessageToBeThrown($message, $type = null)
     {
@@ -25,17 +23,6 @@ abstract class AbstractCompilerTest extends TestCase
         }
 
         $this->setExpectedException($type ?: Exception::class, $message, null);
-    }
-
-    protected function prepareTest()
-    {
-        $this->compiler = new Compiler([
-            'paths'    => [__DIR__.'/../templates'],
-            'patterns' => [
-                'expression_in_text' => '%s',
-                'expression_in_bool' => '%s',
-            ],
-        ]);
     }
 
     protected function enableJsPhpize()
@@ -103,91 +90,5 @@ abstract class AbstractCompilerTest extends TestCase
         });
 
         $this->compiler = $compiler;
-    }
-
-    protected function implodeLines($str)
-    {
-        return preg_replace_callback('/(\s+[a-z0-9:_-]+="(?:\\\\[\\S\\s]|[^"\\\\])*")+/', function ($matches) {
-            $attributes = [];
-            $input = $matches[0];
-            while (mb_strlen($input) && preg_match(
-                '/^\s+([a-z0-9:_-]+)="((?:\\\\[\\S\\s]|[^"\\\\])*)"/',
-                $input,
-                $match
-            )) {
-                if ($match[1] === 'class') {
-                    $classes = explode(' ', $match[2]);
-                    sort($classes);
-                    $match[2] = implode(' ', $classes);
-                }
-                $attributes[] = trim($match[1]).'="'.$match[2].'"';
-                $input = mb_substr($input, mb_strlen($match[0]));
-            }
-            sort($attributes);
-
-            return ' '.implode(' ', $attributes);
-        }, is_string($str) ? $str : implode('', $str));
-    }
-
-    protected function assertSameLines($expected, $actual)
-    {
-        self::assertSame($this->implodeLines($expected), $this->implodeLines($actual));
-    }
-
-    protected function assertCompile($expected, $actual, array $options = [])
-    {
-        $compiler = clone $this->compiler;
-        $compiler->setOptionsRecursive($options);
-
-        return $this->assertSameLines($expected, $compiler->compile($this->implodeLines($actual)));
-    }
-
-    protected function assertCompileFile($expected, $actual)
-    {
-        return $this->assertSameLines($expected, $this->compiler->compileFile($actual));
-    }
-
-    protected function getRenderedHtml($php, array $variables = [])
-    {
-        if (getenv('LOG_COMPILE')) {
-            file_put_contents('temp.php', $php);
-        }
-        extract($variables);
-        ob_start();
-        eval('?>'.$php);
-        $actual = ob_get_contents();
-        ob_end_clean();
-
-        return $actual;
-    }
-
-    protected function render($actual, array $options = [], array $variables = [])
-    {
-        $compiler = $this->compiler;
-        $compiler->setOptionsRecursive($options);
-        $php = $compiler->compile($this->implodeLines($actual));
-
-        return $this->getRenderedHtml($php, $variables);
-    }
-
-    protected function assertRender($expected, $actual, array $options = [], array $variables = [])
-    {
-        $actual = $this->render($actual, $options, $variables);
-
-        return $this->assertSameLines($expected, $actual);
-    }
-
-    protected function assertRenderFile($expected, $actual, array $options = [], array $variables = [])
-    {
-        $compiler = $this->compiler;
-        $compiler->setOptionsRecursive($options);
-        $php = $compiler->compileFile($actual);
-        $actual = preg_replace(
-            '/\s(class|id)=""/',
-            '',
-            $this->getRenderedHtml($php, $variables)
-        );
-
-        return $this->assertSameLines($expected, $actual);
     }
 }

--- a/tests/Phug/Adapter/FileAdapterTest.php
+++ b/tests/Phug/Adapter/FileAdapterTest.php
@@ -575,7 +575,9 @@ class FileAdapterTest extends AbstractRendererTest
      * @covers                \Phug\Renderer\Adapter\FileAdapter::cacheDirectory
      * @covers                \Phug\Renderer\Adapter\FileAdapter::getCacheDirectory
      * @covers                \Phug\Renderer\Partial\Debug\DebuggerTrait::getDebuggedException
+     *
      * @expectedException     \RuntimeException
+     *
      * @expectedExceptionCode 5
      */
     public function testMissingDirectory()
@@ -594,7 +596,9 @@ class FileAdapterTest extends AbstractRendererTest
      * @covers                \Phug\Renderer\Adapter\FileAdapter::cacheDirectory
      * @covers                \Phug\Renderer\Adapter\FileAdapter::cache
      * @covers                \Phug\Renderer\Adapter\FileAdapter::displayCached
+     *
      * @expectedException     \RuntimeException
+     *
      * @expectedExceptionCode 6
      */
     public function testReadOnlyDirectory()

--- a/tests/Phug/Ast/NodeTest.php
+++ b/tests/Phug/Ast/NodeTest.php
@@ -282,6 +282,7 @@ class NodeTest extends TestCase
 
     /**
      * @covers ::getChildAt
+     *
      * @expectedException \Phug\AstException
      */
     public function testGetChildAtWithInvalidOffset()
@@ -309,6 +310,7 @@ class NodeTest extends TestCase
 
     /**
      * @covers ::removeChildAt
+     *
      * @expectedException \Phug\AstException
      */
     public function testRemoveChildAtWithInvalidOffset()
@@ -447,7 +449,9 @@ class NodeTest extends TestCase
 
     /**
      * @covers                   ::insertBefore
+     *
      * @expectedException        \Phug\AstException
+     *
      * @expectedExceptionMessage Failed to insert before: Passed child is not a child of element to insert in
      */
     public function testInsertBeforeWithBadSibling()
@@ -481,7 +485,9 @@ class NodeTest extends TestCase
 
     /**
      * @covers                   ::insertAfter
+     *
      * @expectedException        \Phug\AstException
+     *
      * @expectedExceptionMessage Failed to insert after: Passed child is not a child of element to insert in
      */
     public function testInsertAfterWithBadSibling()
@@ -562,7 +568,9 @@ class NodeTest extends TestCase
 
     /**
      * @covers                   ::offsetSet
+     *
      * @expectedException        \InvalidArgumentException
+     *
      * @expectedExceptionMessage Argument 2 passed to Node->offsetSet needs to be instance of Phug\Ast\NodeInterface
      */
     public function testOffsetSetInvalidArgument()

--- a/tests/Phug/CasesTest.php
+++ b/tests/Phug/CasesTest.php
@@ -21,7 +21,9 @@ class CasesTest extends AbstractRendererTest
 
     /**
      * @group cases
+     *
      * @dataProvider caseProvider
+     *
      * @covers ::compileFile
      * @covers ::render
      */

--- a/tests/Phug/CliTest.php
+++ b/tests/Phug/CliTest.php
@@ -44,6 +44,7 @@ class CliTest extends TestCase
 
     /**
      * @group cli
+     *
      * @covers ::getCustomMethods
      */
     public function testGetCustomMethods()
@@ -73,6 +74,7 @@ class CliTest extends TestCase
 
     /**
      * @group cli
+     *
      * @covers ::convertToKebabCase
      * @covers ::convertToCamelCase
      * @covers ::getNamedArgumentBySpaceDelimiter
@@ -104,6 +106,7 @@ class CliTest extends TestCase
 
     /**
      * @group cli
+     *
      * @covers ::convertToKebabCase
      * @covers ::convertToCamelCase
      * @covers ::execute
@@ -158,6 +161,7 @@ class CliTest extends TestCase
 
     /**
      * @group cli
+     *
      * @covers ::convertToKebabCase
      * @covers ::convertToCamelCase
      * @covers ::execute
@@ -175,6 +179,7 @@ class CliTest extends TestCase
 
     /**
      * @group cli
+     *
      * @covers ::convertToKebabCase
      * @covers ::convertToCamelCase
      * @covers ::getNamedArgumentBySpaceDelimiter
@@ -196,6 +201,7 @@ class CliTest extends TestCase
 
     /**
      * @group cli
+     *
      * @covers ::convertToKebabCase
      * @covers ::convertToCamelCase
      * @covers ::getNamedArgumentBySpaceDelimiter
@@ -258,6 +264,7 @@ class CliTest extends TestCase
 
     /**
      * @group cli
+     *
      * @covers ::convertToKebabCase
      * @covers ::convertToCamelCase
      * @covers ::getNamedArgumentBySpaceDelimiter
@@ -298,6 +305,7 @@ class CliTest extends TestCase
 
     /**
      * @group cli
+     *
      * @covers ::convertToKebabCase
      * @covers ::convertToCamelCase
      * @covers ::getNamedArgumentBySpaceDelimiter

--- a/tests/Phug/Compiler/NodeCompiler/AssignmentListNodeCompilerTest.php
+++ b/tests/Phug/Compiler/NodeCompiler/AssignmentListNodeCompilerTest.php
@@ -25,6 +25,7 @@ class AssignmentListNodeCompilerTest extends AbstractCompilerTest
 
     /**
      * @covers            ::<public>
+     *
      * @expectedException \Phug\CompilerException
      */
     public function testException()

--- a/tests/Phug/Compiler/NodeCompiler/AssignmentNodeCompilerTest.php
+++ b/tests/Phug/Compiler/NodeCompiler/AssignmentNodeCompilerTest.php
@@ -46,6 +46,7 @@ class AssignmentNodeCompilerTest extends AbstractCompilerTest
 
     /**
      * @covers            ::<public>
+     *
      * @expectedException \Phug\CompilerException
      */
     public function testException()

--- a/tests/Phug/Compiler/NodeCompiler/AssignmentNodeCompilerTest.php
+++ b/tests/Phug/Compiler/NodeCompiler/AssignmentNodeCompilerTest.php
@@ -38,6 +38,10 @@ class AssignmentNodeCompilerTest extends AbstractCompilerTest
             '<a href="/"></a>',
             'a&attributes(["href" => "/"])(href="#")'
         );
+        $this->assertRender(
+            '<a href="/" id="biz"></a>',
+            'a(href="#")&attributes(["href" => "/"])&attributes(["id" => "biz"])#boom(id="bam")'
+        );
     }
 
     /**

--- a/tests/Phug/Compiler/NodeCompiler/AttributeListCompilerTest.php
+++ b/tests/Phug/Compiler/NodeCompiler/AttributeListCompilerTest.php
@@ -25,6 +25,7 @@ class AttributeListCompilerTest extends AbstractCompilerTest
 
     /**
      * @covers            ::<public>
+     *
      * @expectedException \Phug\CompilerException
      */
     public function testException()

--- a/tests/Phug/Compiler/NodeCompiler/AttributeNodeCompilerTest.php
+++ b/tests/Phug/Compiler/NodeCompiler/AttributeNodeCompilerTest.php
@@ -77,6 +77,7 @@ class AttributeNodeCompilerTest extends AbstractCompilerTest
 
     /**
      * @covers            ::<public>
+     *
      * @expectedException \Phug\CompilerException
      */
     public function testException()
@@ -92,6 +93,7 @@ class AttributeNodeCompilerTest extends AbstractCompilerTest
 
     /**
      * @covers            ::compileValue
+     *
      * @expectedException \Phug\CompilerException
      */
     public function testAttributeException()

--- a/tests/Phug/Compiler/NodeCompiler/BlockNodeCompilerTest.php
+++ b/tests/Phug/Compiler/NodeCompiler/BlockNodeCompilerTest.php
@@ -38,6 +38,7 @@ class BlockNodeCompilerTest extends AbstractCompilerTest
 
     /**
      * @covers            ::<public>
+     *
      * @expectedException \Phug\CompilerException
      */
     public function testException()
@@ -53,6 +54,7 @@ class BlockNodeCompilerTest extends AbstractCompilerTest
 
     /**
      * @covers            \Phug\Compiler::compileBlocks
+     *
      * @expectedException \Phug\CompilerException
      */
     public function testCompileBlocksException()

--- a/tests/Phug/Compiler/NodeCompiler/CaseNodeCompilerTest.php
+++ b/tests/Phug/Compiler/NodeCompiler/CaseNodeCompilerTest.php
@@ -73,6 +73,7 @@ class CaseNodeCompilerTest extends AbstractCompilerTest
 
     /**
      * @covers            ::<public>
+     *
      * @expectedException \Phug\CompilerException
      */
     public function testException()

--- a/tests/Phug/Compiler/NodeCompiler/CodeNodeCompilerTest.php
+++ b/tests/Phug/Compiler/NodeCompiler/CodeNodeCompilerTest.php
@@ -49,6 +49,7 @@ class CodeNodeCompilerTest extends AbstractCompilerTest
     /**
      * @covers            ::<public>
      * @covers            ::getCodeElement
+     *
      * @expectedException \Phug\CompilerException
      */
     public function testException()

--- a/tests/Phug/Compiler/NodeCompiler/CommentNodeCompilerTest.php
+++ b/tests/Phug/Compiler/NodeCompiler/CommentNodeCompilerTest.php
@@ -30,6 +30,7 @@ class CommentNodeCompilerTest extends AbstractCompilerTest
     /**
      * @covers            ::<public>
      * @covers            \Phug\CompilerException::<public>
+     *
      * @expectedException \Phug\CompilerException
      */
     public function testException()

--- a/tests/Phug/Compiler/NodeCompiler/ConditionalNodeCompilerTest.php
+++ b/tests/Phug/Compiler/NodeCompiler/ConditionalNodeCompilerTest.php
@@ -62,6 +62,7 @@ class ConditionalNodeCompilerTest extends AbstractCompilerTest
 
     /**
      * @covers            ::<public>
+     *
      * @expectedException \Phug\CompilerException
      */
     public function testException()

--- a/tests/Phug/Compiler/NodeCompiler/DoNodeCompilerTest.php
+++ b/tests/Phug/Compiler/NodeCompiler/DoNodeCompilerTest.php
@@ -14,6 +14,7 @@ class DoNodeCompilerTest extends AbstractCompilerTest
 {
     /**
      * @covers            ::<public>
+     *
      * @expectedException \Phug\CompilerException
      */
     public function testException()

--- a/tests/Phug/Compiler/NodeCompiler/DoctypeNodeCompilerTest.php
+++ b/tests/Phug/Compiler/NodeCompiler/DoctypeNodeCompilerTest.php
@@ -29,6 +29,7 @@ class DoctypeNodeCompilerTest extends AbstractCompilerTest
 
     /**
      * @covers            ::<public>
+     *
      * @expectedException \Phug\CompilerException
      */
     public function testException()

--- a/tests/Phug/Compiler/NodeCompiler/DocumentNodeCompilerTest.php
+++ b/tests/Phug/Compiler/NodeCompiler/DocumentNodeCompilerTest.php
@@ -22,6 +22,7 @@ class DocumentNodeCompilerTest extends AbstractCompilerTest
 
     /**
      * @covers            ::<public>
+     *
      * @expectedException \Phug\CompilerException
      */
     public function testException()

--- a/tests/Phug/Compiler/NodeCompiler/EachNodeCompilerTest.php
+++ b/tests/Phug/Compiler/NodeCompiler/EachNodeCompilerTest.php
@@ -210,6 +210,7 @@ class EachNodeCompilerTest extends AbstractCompilerTest
 
     /**
      * @covers            ::<public>
+     *
      * @expectedException \Phug\CompilerException
      */
     public function testException()

--- a/tests/Phug/Compiler/NodeCompiler/ElementNodeCompilerTest.php
+++ b/tests/Phug/Compiler/NodeCompiler/ElementNodeCompilerTest.php
@@ -36,6 +36,7 @@ class ElementNodeCompilerTest extends AbstractCompilerTest
 
     /**
      * @covers            ::<public>
+     *
      * @expectedException \Phug\CompilerException
      */
     public function testException()

--- a/tests/Phug/Compiler/NodeCompiler/ExpressionNodeCompilerTest.php
+++ b/tests/Phug/Compiler/NodeCompiler/ExpressionNodeCompilerTest.php
@@ -29,6 +29,7 @@ class ExpressionNodeCompilerTest extends AbstractCompilerTest
 
     /**
      * @covers            ::<public>
+     *
      * @expectedException \Phug\CompilerException
      */
     public function testException()

--- a/tests/Phug/Compiler/NodeCompiler/FilterNodeCompilerTest.php
+++ b/tests/Phug/Compiler/NodeCompiler/FilterNodeCompilerTest.php
@@ -97,6 +97,7 @@ class FilterNodeCompilerTest extends AbstractCompilerTest
 
     /**
      * @covers            ::<public>
+     *
      * @expectedException \Phug\CompilerException
      */
     public function testWrongFilterException()
@@ -164,6 +165,7 @@ class FilterNodeCompilerTest extends AbstractCompilerTest
 
     /**
      * @covers            ::compileText
+     *
      * @expectedException \Phug\CompilerException
      */
     public function testFilterChildrenException()
@@ -192,6 +194,7 @@ class FilterNodeCompilerTest extends AbstractCompilerTest
 
     /**
      * @covers            ::<public>
+     *
      * @expectedException \Phug\CompilerException
      */
     public function testException()

--- a/tests/Phug/Compiler/NodeCompiler/ImportNodeCompilerTest.php
+++ b/tests/Phug/Compiler/NodeCompiler/ImportNodeCompilerTest.php
@@ -15,6 +15,7 @@ class ImportNodeCompilerTest extends AbstractCompilerTest
 {
     /**
      * @covers            ::<public>
+     *
      * @expectedException \Phug\CompilerException
      */
     public function testException()
@@ -294,6 +295,7 @@ class ImportNodeCompilerTest extends AbstractCompilerTest
 
     /**
      * @covers            \Phug\Compiler::compileIntoElement
+     *
      * @expectedException \Phug\CompilerException
      */
     public function testCompileIntoElementException()
@@ -345,6 +347,7 @@ class ImportNodeCompilerTest extends AbstractCompilerTest
 
     /**
      * @covers            \Phug\Compiler::throwException
+     *
      * @expectedException \Phug\CompilerException
      */
     public function testFileNotFoundInFileException()

--- a/tests/Phug/Compiler/NodeCompiler/ImportNodeCompilerTest.php
+++ b/tests/Phug/Compiler/NodeCompiler/ImportNodeCompilerTest.php
@@ -180,7 +180,7 @@ class ImportNodeCompilerTest extends AbstractCompilerTest
         $expected = file_get_contents(__DIR__.'/../../../templates/yield-in-sub-include.html');
 
         $this->assertCompileFile(
-            str_replace("\n", '', $expected),
+            str_replace(["\r", "\n"], '', $expected),
             __DIR__.'/../../../templates/yield-in-sub-include.pug'
         );
     }
@@ -193,7 +193,7 @@ class ImportNodeCompilerTest extends AbstractCompilerTest
         $expected = file_get_contents(__DIR__.'/../../../templates/inheritance.extend.mixins.html');
 
         $this->assertRenderFile(
-            preg_replace('/\n\s*/', '', $expected),
+            preg_replace('/\r?\n\s*/', '', $expected),
             __DIR__.'/../../../templates/inheritance.extend.mixins.pug'
         );
     }

--- a/tests/Phug/Compiler/NodeCompiler/KeywordNodeCompilerTest.php
+++ b/tests/Phug/Compiler/NodeCompiler/KeywordNodeCompilerTest.php
@@ -48,6 +48,7 @@ class KeywordNodeCompilerTest extends AbstractCompilerTest
 
     /**
      * @covers            ::<public>
+     *
      * @expectedException \Phug\CompilerException
      */
     public function testException()

--- a/tests/Phug/Compiler/NodeCompiler/MixinCallNodeCompilerTest.php
+++ b/tests/Phug/Compiler/NodeCompiler/MixinCallNodeCompilerTest.php
@@ -16,6 +16,7 @@ class MixinCallNodeCompilerTest extends AbstractCompilerTest
 {
     /**
      * @group  mixins
+     *
      * @covers ::<public>
      * @covers \Phug\Compiler\NodeCompiler\BlockNodeCompiler::<public>
      * @covers \Phug\Compiler\NodeCompiler\BlockNodeCompiler::compileAnonymousBlock
@@ -54,6 +55,7 @@ class MixinCallNodeCompilerTest extends AbstractCompilerTest
 
     /**
      * @group  mixins
+     *
      * @covers ::<public>
      */
     public function testCompileNestedMixins()
@@ -82,6 +84,7 @@ class MixinCallNodeCompilerTest extends AbstractCompilerTest
 
     /**
      * @group  mixins
+     *
      * @covers ::<public>
      */
     public function testCompileVariadicMixin()
@@ -104,6 +107,7 @@ class MixinCallNodeCompilerTest extends AbstractCompilerTest
 
     /**
      * @group  mixins
+     *
      * @covers ::<public>
      * @covers \Phug\Compiler\NodeCompiler\BlockNodeCompiler::<public>
      * @covers \Phug\Compiler\NodeCompiler\BlockNodeCompiler::compileAnonymousBlock
@@ -124,6 +128,7 @@ class MixinCallNodeCompilerTest extends AbstractCompilerTest
 
     /**
      * @group  mixins
+     *
      * @covers ::<public>
      * @covers \Phug\Compiler::compileDocument
      * @covers \Phug\Compiler\NodeCompiler\BlockNodeCompiler::compileAnonymousBlock
@@ -177,6 +182,7 @@ class MixinCallNodeCompilerTest extends AbstractCompilerTest
 
     /**
      * @group  mixins
+     *
      * @covers ::<public>
      * @covers \Phug\Compiler\NodeCompiler\MixinNodeCompiler::<public>
      */
@@ -274,6 +280,7 @@ class MixinCallNodeCompilerTest extends AbstractCompilerTest
 
     /**
      * @group  mixins
+     *
      * @covers ::<public>
      * @covers \Phug\Compiler\NodeCompiler\BlockNodeCompiler::<public>
      * @covers \Phug\Compiler\NodeCompiler\BlockNodeCompiler::compileAnonymousBlock
@@ -299,6 +306,7 @@ class MixinCallNodeCompilerTest extends AbstractCompilerTest
 
     /**
      * @group  mixins
+     *
      * @covers ::<public>
      * @covers \Phug\Compiler\NodeCompiler\BlockNodeCompiler::<public>
      * @covers \Phug\Compiler\NodeCompiler\BlockNodeCompiler::compileAnonymousBlock

--- a/tests/Phug/Compiler/NodeCompiler/MixinNodeCompilerTest.php
+++ b/tests/Phug/Compiler/NodeCompiler/MixinNodeCompilerTest.php
@@ -14,6 +14,7 @@ class MixinNodeCompilerTest extends AbstractCompilerTest
 {
     /**
      * @covers            ::<public>
+     *
      * @expectedException \Phug\CompilerException
      */
     public function testException()
@@ -29,6 +30,7 @@ class MixinNodeCompilerTest extends AbstractCompilerTest
 
     /**
      * @group mixins
+     *
      * @covers ::<public>
      */
     public function testRecursion()
@@ -60,6 +62,7 @@ class MixinNodeCompilerTest extends AbstractCompilerTest
 
     /**
      * @group mixins
+     *
      * @covers ::<public>
      */
     public function testRecursionWithBlock()
@@ -94,7 +97,9 @@ class MixinNodeCompilerTest extends AbstractCompilerTest
 
     /**
      * @group             mixins
+     *
      * @covers            \Phug\Compiler\NodeCompiler\BlockNodeCompiler ::compileAnonymousBlock
+     *
      * @expectedException \Phug\CompilerException
      */
     public function testAnonymousBlocksOutsideMixin()

--- a/tests/Phug/Compiler/NodeCompiler/TextNodeCompilerTest.php
+++ b/tests/Phug/Compiler/NodeCompiler/TextNodeCompilerTest.php
@@ -62,6 +62,7 @@ class TextNodeCompilerTest extends AbstractCompilerTest
 
     /**
      * @covers            ::<public>
+     *
      * @expectedException \Phug\CompilerException
      */
     public function testException()

--- a/tests/Phug/Compiler/NodeCompiler/VariableNodeCompilerTest.php
+++ b/tests/Phug/Compiler/NodeCompiler/VariableNodeCompilerTest.php
@@ -26,6 +26,7 @@ class VariableNodeCompilerTest extends AbstractCompilerTest
 
     /**
      * @covers            ::<public>
+     *
      * @expectedException \Phug\CompilerException
      */
     public function testExpressionException()
@@ -39,6 +40,7 @@ class VariableNodeCompilerTest extends AbstractCompilerTest
 
     /**
      * @covers            ::<public>
+     *
      * @expectedException \Phug\CompilerException
      */
     public function testException()

--- a/tests/Phug/Compiler/NodeCompiler/WhenNodeCompilerTest.php
+++ b/tests/Phug/Compiler/NodeCompiler/WhenNodeCompilerTest.php
@@ -14,6 +14,7 @@ class WhenNodeCompilerTest extends AbstractCompilerTest
 {
     /**
      * @covers            ::<public>
+     *
      * @expectedException \Phug\CompilerException
      */
     public function testException()

--- a/tests/Phug/Compiler/NodeCompiler/WhileNodeCompilerTest.php
+++ b/tests/Phug/Compiler/NodeCompiler/WhileNodeCompilerTest.php
@@ -64,6 +64,7 @@ class WhileNodeCompilerTest extends AbstractCompilerTest
 
     /**
      * @covers            ::<public>
+     *
      * @expectedException \Phug\CompilerException
      */
     public function testException()
@@ -80,6 +81,7 @@ class WhileNodeCompilerTest extends AbstractCompilerTest
     /**
      * @covers            ::<public>
      * @covers            \Phug\Compiler\NodeCompiler\DoNodeCompiler::<public>
+     *
      * @expectedException \Phug\CompilerException
      */
     public function testDoAndWhileSeededException()

--- a/tests/Phug/Compiler/NodeCompiler/YieldNodeCompilerTest.php
+++ b/tests/Phug/Compiler/NodeCompiler/YieldNodeCompilerTest.php
@@ -14,6 +14,7 @@ class YieldNodeCompilerTest extends AbstractCompilerTest
 {
     /**
      * @covers            ::<public>
+     *
      * @expectedException \Phug\CompilerException
      */
     public function testException()

--- a/tests/Phug/CompilerModuleTest.php
+++ b/tests/Phug/CompilerModuleTest.php
@@ -21,6 +21,7 @@ class CompilerModuleTest extends TestCase
 {
     /**
      * @group modules
+     *
      * @covers ::<public>
      * @covers \Phug\Compiler\Event\CompileEvent::<public>
      */
@@ -53,6 +54,7 @@ class CompilerModuleTest extends TestCase
 
     /**
      * @group modules
+     *
      * @covers ::<public>
      * @covers \Phug\Compiler\Event\OutputEvent::<public>
      */
@@ -174,6 +176,7 @@ class CompilerModuleTest extends TestCase
 
     /**
      * @group modules
+     *
      * @covers ::<public>
      * @covers \Phug\Compiler\Event\NodeEvent::<public>
      */
@@ -245,6 +248,7 @@ class CompilerModuleTest extends TestCase
 
     /**
      * @group modules
+     *
      * @covers ::<public>
      * @covers \Phug\Compiler\Event\ElementEvent::<public>
      */

--- a/tests/Phug/CompilerTest.php
+++ b/tests/Phug/CompilerTest.php
@@ -162,6 +162,7 @@ class CompilerTest extends AbstractCompilerTest
 
     /**
      * @covers            ::__construct
+     *
      * @expectedException \InvalidArgumentException
      */
     public function testParserClassException()
@@ -180,6 +181,7 @@ class CompilerTest extends AbstractCompilerTest
 
     /**
      * @covers            ::__construct
+     *
      * @expectedException \InvalidArgumentException
      */
     public function testFormatterClassException()
@@ -198,6 +200,7 @@ class CompilerTest extends AbstractCompilerTest
 
     /**
      * @covers            ::__construct
+     *
      * @expectedException \InvalidArgumentException
      */
     public function testLocatorClassException()
@@ -213,6 +216,7 @@ class CompilerTest extends AbstractCompilerTest
 
     /**
      * @covers            ::setNodeCompiler
+     *
      * @expectedException \InvalidArgumentException
      */
     public function testSetNodeCompilerException()
@@ -228,6 +232,7 @@ class CompilerTest extends AbstractCompilerTest
 
     /**
      * @covers            ::compileNode
+     *
      * @expectedException \Phug\CompilerException
      */
     public function testCompileNodeException()
@@ -246,6 +251,7 @@ class CompilerTest extends AbstractCompilerTest
      * @covers            ::locate
      * @covers            ::resolve
      * @covers            \Phug\Compiler\NodeCompiler\ImportNodeCompiler::compileNode
+     *
      * @expectedException \Phug\CompilerException
      */
     public function testAbsolutePathWithoutPaths()
@@ -283,7 +289,9 @@ class CompilerTest extends AbstractCompilerTest
 
     /**
      * @covers ::resolve
+     *
      * @expectedException \Phug\CompilerException
+     *
      * @expectedExceptionMessage Source file not-existent not found
      */
     public function testResolveNotFoundException()
@@ -294,6 +302,7 @@ class CompilerTest extends AbstractCompilerTest
 
     /**
      * @group hooks
+     *
      * @covers ::compileNode
      * @covers ::compile
      * @covers ::__construct
@@ -409,6 +418,7 @@ class CompilerTest extends AbstractCompilerTest
 
     /**
      * @covers ::throwException
+     *
      * @expectedException \Phug\CompilerException
      */
     public function testThrowException()
@@ -419,7 +429,9 @@ class CompilerTest extends AbstractCompilerTest
 
     /**
      * @covers ::throwException
+     *
      * @expectedException \Phug\CompilerException
+     *
      * @expectedExceptionMessage foobar.pug
      */
     public function testThrowExceptionFileName()
@@ -441,6 +453,7 @@ class CompilerTest extends AbstractCompilerTest
 
     /**
      * @covers ::assert
+     *
      * @expectedException \Phug\CompilerException
      */
     public function testAssertFailure()
@@ -451,7 +464,9 @@ class CompilerTest extends AbstractCompilerTest
 
     /**
      * @covers                   ::initializeFormatter
+     *
      * @expectedException        \InvalidArgumentException
+     *
      * @expectedExceptionMessage Passed formatter class stdClass is not a valid Phug\Formatter
      */
     public function testInitializeFormatterException()
@@ -594,7 +609,9 @@ class CompilerTest extends AbstractCompilerTest
 
     /**
      * @covers                   ::compileNode
+     *
      * @expectedException        \Phug\CompilerException
+     *
      * @expectedExceptionMessage Failed to compile: No compiler found able to compile Phug\Test\Utils\UnknownNode
      */
     public function testUnknownNodeThrowException()

--- a/tests/Phug/Element/AssignmentElementTest.php
+++ b/tests/Phug/Element/AssignmentElementTest.php
@@ -162,7 +162,9 @@ class AssignmentElementTest extends TestCase
      * @covers                   \Phug\Formatter\Format\XmlFormat::formatAttributeAssignments
      * @covers                   \Phug\Formatter\Format\XmlFormat::yieldAssignmentAttributes
      * @covers                   \Phug\Formatter\Format\XmlFormat::formatMarkupAttributes
+     *
      * @expectedException        \Phug\FormatterException
+     *
      * @expectedExceptionMessage Unable to handle class assignment
      */
     public function testFormatAssignmentElementException()

--- a/tests/Phug/Element/KeywordElementTest.php
+++ b/tests/Phug/Element/KeywordElementTest.php
@@ -112,7 +112,9 @@ class KeywordElementTest extends TestCase
 
     /**
      * @covers                   \Phug\Formatter\AbstractFormat::formatKeywordElement
+     *
      * @expectedException        \Phug\FormatterException
+     *
      * @expectedExceptionMessage The keyword foo returned an invalid value type
      */
     public function testBadReturn()

--- a/tests/Phug/Event/ListenerQueueTest.php
+++ b/tests/Phug/Event/ListenerQueueTest.php
@@ -57,7 +57,9 @@ class ListenerQueueTest extends TestCase
 
     /**
      * @covers                   ::insertMultiple
+     *
      * @expectedException        \InvalidArgumentException
+     *
      * @expectedExceptionMessage insertMultiple only accept array or Traversable as first argument
      */
     public function testInsertMultipleBadType()
@@ -70,7 +72,9 @@ class ListenerQueueTest extends TestCase
 
     /**
      * @covers                   ::insertMultiple
+     *
      * @expectedException        \InvalidArgumentException
+     *
      * @expectedExceptionMessage Callback inserted into ListenerQueue needs to be callable
      */
     public function testInsertMultipleBadSubInsert()
@@ -110,6 +114,7 @@ class ListenerQueueTest extends TestCase
 
     /**
      * @covers ::insert
+     *
      * @dataProvider provideParameterValues
      */
     public function testInsertWithNonCallback($parameterValue)

--- a/tests/Phug/Format/FakeFormat.php
+++ b/tests/Phug/Format/FakeFormat.php
@@ -19,20 +19,24 @@ class FakeFormat extends AbstractFormat implements ArrayAccess
         return $helper($element->getName());
     }
 
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return strpos($offset, 'non_existing') === false;
     }
 
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $offset;
     }
 
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
     }
 
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
     }

--- a/tests/Phug/Format/HtmlFormatTest.php
+++ b/tests/Phug/Format/HtmlFormatTest.php
@@ -209,7 +209,9 @@ class HtmlFormatTest extends TestCase
     /**
      * @covers                   \Phug\Formatter\AbstractFormat::throwException
      * @covers                   \Phug\Formatter\Format\XmlFormat::isSelfClosingTag
+     *
      * @expectedException        \Phug\FormatterException
+     *
      * @expectedExceptionMessage input is a self closing element: <input/> but contains nested content.
      */
     public function testChildrenInSelfClosingTag()
@@ -237,7 +239,9 @@ class HtmlFormatTest extends TestCase
     /**
      * @covers                   \Phug\Formatter\AbstractFormat::throwException
      * @covers                   \Phug\Formatter\Format\XmlFormat::isSelfClosingTag
+     *
      * @expectedException        \Phug\FormatterException
+     *
      * @expectedExceptionMessage input is a self closing element: <input/> but contains nested content.
      */
     public function testTextInSelfClosingTag()

--- a/tests/Phug/Format/XmlFormatTest.php
+++ b/tests/Phug/Format/XmlFormatTest.php
@@ -2,6 +2,7 @@
 
 namespace Phug\Test\Format;
 
+use InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
 use Phug\Formatter;
 use Phug\Formatter\Element\AssignmentElement;
@@ -17,6 +18,8 @@ use Phug\Formatter\ElementInterface;
 use Phug\Formatter\Format\BasicFormat;
 use Phug\Formatter\Format\XmlFormat;
 use Phug\Parser\Node\TextNode;
+use Phug\Test\Utils\AssertRender;
+use Phug\Util\OrderedValue;
 use SplObjectStorage;
 
 /**
@@ -24,6 +27,8 @@ use SplObjectStorage;
  */
 class XmlFormatTest extends TestCase
 {
+    use AssertRender;
+
     /**
      * @covers ::__construct
      * @covers \Phug\Formatter\AbstractFormat::__construct
@@ -636,6 +641,7 @@ class XmlFormatTest extends TestCase
      * @covers ::yieldAssignmentAttributes
      * @covers ::formatMarkupAttributes
      * @covers ::formatAttributes
+     * @covers ::formatInnerCodeValue
      */
     public function testAttributeAssignmentsOption()
     {
@@ -666,6 +672,157 @@ class XmlFormatTest extends TestCase
         self::assertSame(
             '<a data-user="{"name":{"first":"Linus","last":"Trosvald"}}"></a>',
             $actual
+        );
+    }
+
+    /**
+     * @covers ::yieldAssignmentElement
+     * @covers ::formatOrderedAttributeAssignments
+     * @covers ::formatOrderedMarkupAttributes
+     * @covers ::formatInnerCodeValue
+     */
+    public function testAttributeAttributePrecedence()
+    {
+        $this->prepareTest();
+
+        // Take Attribute over Assignment
+        $this->assertRender(
+            '<a href="#"></a>',
+            'a&attributes(["href" => "#"])',
+            ['attribute_precedence' => 'attribute']
+        );
+        $this->assertRender(
+            '<a class="bar fiz foo biz"></a>',
+            'a.foo(class=["bar", "biz"])&attributes(["class" => "bar fiz"])',
+            ['attribute_precedence' => 'attribute']
+        );
+        $this->assertRender(
+            '<a class="bar fiz foo biz"></a>',
+            'a.foo(class=["bar", "biz"])&attributes(["class" => "bar fiz"])',
+            ['attribute_precedence' => 'attribute']
+        );
+        $this->assertRender(
+            '<a href="#"></a>',
+            'a(href="#")&attributes(["href" => "/"])',
+            ['attribute_precedence' => 'attribute']
+        );
+        $this->assertRender(
+            '<a href="#"></a>',
+            'a&attributes(["href" => "/"])(href="#")',
+            ['attribute_precedence' => 'attribute']
+        );
+        $this->assertRender(
+            '<a href="#" id="bam"></a>',
+            'a(href="#")&attributes(["href" => "/"])&attributes(["id" => "biz"])#boom(id="bam")',
+            ['attribute_precedence' => 'attribute']
+        );
+
+        // Left
+        $this->assertRender(
+            '<a href="#"></a>',
+            'a&attributes(["href" => "#"])',
+            ['attribute_precedence' => 'left']
+        );
+        $this->assertRender(
+            '<a class="bar fiz foo biz"></a>',
+            'a.foo(class=["bar", "biz"])&attributes(["class" => "bar fiz"])',
+            ['attribute_precedence' => 'left']
+        );
+        $this->assertRender(
+            '<a class="bar fiz foo biz"></a>',
+            'a.foo(class=["bar", "biz"])&attributes(["class" => "bar fiz"])',
+            ['attribute_precedence' => 'left']
+        );
+        $this->assertRender(
+            '<a href="#"></a>',
+            'a(href="#")&attributes(["href" => "/"])',
+            ['attribute_precedence' => 'left']
+        );
+        $this->assertRender(
+            '<a href="/"></a>',
+            'a&attributes(["href" => "/"])(href="#")',
+            ['attribute_precedence' => 'left']
+        );
+        $this->assertRender(
+            '<a href="#" id="biz"></a>',
+            'a(href="#")&attributes(["href" => "/"])&attributes(["id" => "biz"])#boom(id="bam")',
+            ['attribute_precedence' => 'left']
+        );
+        $this->assertRender(
+            '<a href="#" id="boom"></a>',
+            'a(href="#")&attributes(["href" => "/"])#boom&attributes(["id" => "biz"])(id="bam")',
+            ['attribute_precedence' => 'left']
+        );
+
+        // Right
+        $this->assertRender(
+            '<a href="#"></a>',
+            'a&attributes(["href" => "#"])',
+            ['attribute_precedence' => 'right']
+        );
+        $this->assertRender(
+            '<a class="bar fiz foo biz"></a>',
+            'a.foo(class=["bar", "biz"])&attributes(["class" => "bar fiz"])',
+            ['attribute_precedence' => 'right']
+        );
+        $this->assertRender(
+            '<a class="bar fiz foo biz"></a>',
+            'a.foo(class=["bar", "biz"])&attributes(["class" => "bar fiz"])',
+            ['attribute_precedence' => 'right']
+        );
+        $this->assertRender(
+            '<a href="/"></a>',
+            'a(href="#")&attributes(["href" => "/"])',
+            ['attribute_precedence' => 'right']
+        );
+        $this->assertRender(
+            '<a href="#"></a>',
+            'a&attributes(["href" => "/"])(href="#")',
+            ['attribute_precedence' => 'right']
+        );
+        $this->assertRender(
+            '<a href="/" id="bam"></a>',
+            'a(href="#")&attributes(["href" => "/"])&attributes(["id" => "biz"])#boom(id="bam")',
+            ['attribute_precedence' => 'right']
+        );
+        $this->assertRender(
+            '<a href="/" id="boom"></a>',
+            'a(href="#")&attributes(["href" => "/"])&attributes(["id" => "biz"])(id="bam")#boom',
+            ['attribute_precedence' => 'right']
+        );
+
+        $this->assertRender(
+            '<a href="#stuff" id="boom"></a>',
+            'a(href="#stuff")&attributes(["href" => "/"])&attributes(["id" => "biz"])#boom(id="bam")',
+            ['attribute_precedence' => static function (array $assignments, array $attributes) {
+                $arguments = array_merge($assignments, $attributes);
+
+                usort($arguments, static function (OrderedValue $a, OrderedValue $b) {
+                    return strlen($a->getValue()) - strlen($b->getValue());
+                });
+
+                return $arguments;
+            }]
+        );
+    }
+
+    /**
+     * @covers ::yieldAssignmentElement
+     * @covers ::formatOrderedAttributeAssignments
+     * @covers ::formatOrderedMarkupAttributes
+     * @covers ::formatInnerCodeValue
+     */
+    public function testAttributeAttributePrecedenceFailure()
+    {
+        self::expectExceptionObject(new InvalidArgumentException(
+            'Option attribute_precedence must be "assignment" (default), "attribute", "left", "right" or a callable.',
+        ));
+
+        $this->prepareTest();
+
+        $this->render(
+            'a&attributes(["href" => "#"])',
+            ['attribute_precedence' => 'unknown']
         );
     }
 

--- a/tests/Phug/Format/XmlFormatTest.php
+++ b/tests/Phug/Format/XmlFormatTest.php
@@ -811,13 +811,13 @@ class XmlFormatTest extends TestCase
      * @covers ::formatOrderedAttributeAssignments
      * @covers ::formatOrderedMarkupAttributes
      * @covers ::formatInnerCodeValue
+     *
+     * @expectedException InvalidArgumentException
+     *
+     * @expectedExceptionMessage Option attribute_precedence must be "assignment" (default), "attribute", "left", "right" or a callable.
      */
     public function testAttributeAttributePrecedenceFailure()
     {
-        self::expectExceptionObject(new InvalidArgumentException(
-            'Option attribute_precedence must be "assignment" (default), "attribute", "left", "right" or a callable.',
-        ));
-
         $this->prepareTest();
 
         $this->render(

--- a/tests/Phug/Format/XmlFormatTest.php
+++ b/tests/Phug/Format/XmlFormatTest.php
@@ -678,8 +678,10 @@ class XmlFormatTest extends TestCase
     /**
      * @covers ::yieldAssignmentElement
      * @covers ::formatOrderedAttributeAssignments
+     * @covers ::yieldAssignmentOrderedAttributes
      * @covers ::formatOrderedMarkupAttributes
      * @covers ::formatInnerCodeValue
+     * @covers ::getSortedAttributes
      */
     public function testAttributeAttributePrecedence()
     {
@@ -809,6 +811,7 @@ class XmlFormatTest extends TestCase
     /**
      * @covers ::yieldAssignmentElement
      * @covers ::formatOrderedAttributeAssignments
+     * @covers ::yieldAssignmentOrderedAttributes
      * @covers ::formatOrderedMarkupAttributes
      * @covers ::formatInnerCodeValue
      *

--- a/tests/Phug/FormatterTest.php
+++ b/tests/Phug/FormatterTest.php
@@ -794,6 +794,7 @@ class FormatterTest extends TestCase
 
     /**
      * @group  debug
+     *
      * @covers \Phug\Formatter\AbstractFormat::format
      * @covers \Phug\Formatter\AbstractFormat::formatElementChildren
      * @covers \Phug\Formatter::getSourceLine
@@ -914,6 +915,7 @@ class FormatterTest extends TestCase
 
     /**
      * @group  debug
+     *
      * @covers \Phug\Formatter::getSourceLine
      * @covers \Phug\Formatter::getDebugError
      */

--- a/tests/Phug/FormatterTest.php
+++ b/tests/Phug/FormatterTest.php
@@ -450,7 +450,7 @@ class FormatterTest extends TestCase
         self::assertSame(
             '<?= (is_array($_pug_temp = $foo->bar) || is_object($_pug_temp) && '.
             '!method_exists($_pug_temp, "__toString") ? json_encode($_pug_temp) : strval($_pug_temp)) ?>',
-            $formatter->format($expression, HtmlFormat::class)
+            preg_replace('/\s+/', ' ', $formatter->format($expression, HtmlFormat::class))
         );
 
         $attribute = new AttributeElement('class', new ExpressionElement('$foo.bar'));

--- a/tests/Phug/Invoker/InvokerTest.php
+++ b/tests/Phug/Invoker/InvokerTest.php
@@ -23,6 +23,7 @@ class InvokerTest extends TestCase
      * @covers ::getCallbackType
      *
      * @expectedException        RuntimeException
+     *
      * @expectedExceptionMessage Passed callback #1 should have at least 1 argument and this first argument must have a typehint.
      *
      * @throws ReflectionException
@@ -40,6 +41,7 @@ class InvokerTest extends TestCase
      * @covers ::addCallback
      *
      * @expectedException        RuntimeException
+     *
      * @expectedExceptionMessage The #2 value is not callable.
      *
      * @throws ReflectionException

--- a/tests/Phug/Lexer/Scanner/AttributeScannerTest.php
+++ b/tests/Phug/Lexer/Scanner/AttributeScannerTest.php
@@ -197,6 +197,7 @@ class AttributeScannerTest extends AbstractLexerTest
      * @covers            \Phug\Lexer\Scanner\AttributeScanner::scanParenthesesContent
      * @covers            \Phug\Lexer\Scanner\AttributeScanner::scanParentheses
      * @covers            \Phug\Lexer\Scanner\AttributeScanner::scan
+     *
      * @expectedException \Phug\LexerException
      */
     public function testFailsOnUnclosedBracket()

--- a/tests/Phug/Lexer/Scanner/CaseScannerTest.php
+++ b/tests/Phug/Lexer/Scanner/CaseScannerTest.php
@@ -23,6 +23,7 @@ class CaseScannerTest extends AbstractControlStatementScannerTest
      * @covers \Phug\Lexer\Scanner\ControlStatementScanner::scan
      * @covers \Phug\Lexer\Scanner\Partial\NamespaceAndTernaryTrait::checkForTernary
      * @covers \Phug\Lexer\Scanner\Partial\NamespaceAndTernaryTrait::checkForNamespaceAndTernary
+     *
      * @dataProvider provideExpressions
      */
     public function testExpandedExpressions($expr)

--- a/tests/Phug/Lexer/Scanner/ClassScannerTest.php
+++ b/tests/Phug/Lexer/Scanner/ClassScannerTest.php
@@ -13,7 +13,6 @@ class ClassScannerTest extends AbstractLexerTest
      */
     public function testSingleClass()
     {
-
         /** @var ClassToken $tok */
         list($tok) = $this->assertTokens('.some-class', [
             ClassToken::class,
@@ -28,7 +27,6 @@ class ClassScannerTest extends AbstractLexerTest
      */
     public function testMultipleClasses()
     {
-
         /**
          * @var ClassToken
          * @var ClassToken $b
@@ -50,7 +48,6 @@ class ClassScannerTest extends AbstractLexerTest
 
     public function testCommonNamingPatterns()
     {
-
         /** @var ClassToken $tok */
         list($tok) = $this->assertTokens('.--some-class', [
             ClassToken::class,

--- a/tests/Phug/Lexer/Scanner/ConditionalScannerTest.php
+++ b/tests/Phug/Lexer/Scanner/ConditionalScannerTest.php
@@ -28,6 +28,7 @@ class ConditionalScannerTest extends AbstractControlStatementScannerTest
      * @covers \Phug\Lexer\Scanner\ControlStatementScanner::scan
      * @covers \Phug\Lexer\Scanner\Partial\NamespaceAndTernaryTrait::checkForTernary
      * @covers \Phug\Lexer\Scanner\Partial\NamespaceAndTernaryTrait::checkForNamespaceAndTernary
+     *
      * @dataProvider provideExpressions
      */
     public function testExpandedExpressions($expr)
@@ -119,7 +120,9 @@ class ConditionalScannerTest extends AbstractControlStatementScannerTest
 
     /**
      * @covers                   Phug\Lexer\Scanner\ConditionalScanner::scan
+     *
      * @expectedException        Phug\LexerException
+     *
      * @expectedExceptionMessage The `else`-conditional statement can't have a subject
      */
     public function testElseWithSubject()

--- a/tests/Phug/Lexer/Scanner/DoScannerTest.php
+++ b/tests/Phug/Lexer/Scanner/DoScannerTest.php
@@ -21,7 +21,6 @@ class DoScannerTest extends AbstractLexerTest
      */
     public function testSingleLine()
     {
-
         /* @var DoToken $tok */
         $this->assertTokens("do\n", [DoToken::class, NewLineToken::class]);
     }
@@ -36,7 +35,6 @@ class DoScannerTest extends AbstractLexerTest
      */
     public function testExpanded()
     {
-
         /* @var DoToken $tok */
         $this->assertTokens('do: p something', [
             DoToken::class,

--- a/tests/Phug/Lexer/Scanner/DoctypeScannerTest.php
+++ b/tests/Phug/Lexer/Scanner/DoctypeScannerTest.php
@@ -13,7 +13,6 @@ class DoctypeScannerTest extends AbstractLexerTest
      */
     public function testCommonDoctypes()
     {
-
         /** @var DoctypeToken $tok */
         list($tok) = $this->assertTokens(
             'doctype 5',

--- a/tests/Phug/Lexer/Scanner/EachScannerTest.php
+++ b/tests/Phug/Lexer/Scanner/EachScannerTest.php
@@ -43,11 +43,11 @@ class EachScannerTest extends AbstractLexerTest
      * @covers ::scan
      * @covers \Phug\Lexer\Scanner\Partial\NamespaceAndTernaryTrait::checkForTernary
      * @covers \Phug\Lexer\Scanner\Partial\NamespaceAndTernaryTrait::checkForNamespaceAndTernary
+     *
      * @dataProvider provideExpressions
      */
     public function testWithItemOnly($expr)
     {
-
         /** @var EachToken $tok */
         list($tok) = $this->assertTokens("each \$item in $expr", [EachToken::class]);
 
@@ -59,11 +59,11 @@ class EachScannerTest extends AbstractLexerTest
      * @covers ::scan
      * @covers \Phug\Lexer\Scanner\Partial\NamespaceAndTernaryTrait::checkForTernary
      * @covers \Phug\Lexer\Scanner\Partial\NamespaceAndTernaryTrait::checkForNamespaceAndTernary
+     *
      * @dataProvider provideExpressions
      */
     public function testWithItemAndKey($expr)
     {
-
         /** @var EachToken $tok */
         list($tok) = $this->assertTokens("each \$someItem, \$someKey in $expr", [EachToken::class]);
 
@@ -74,11 +74,11 @@ class EachScannerTest extends AbstractLexerTest
 
     /**
      * @covers ::scan
+     *
      * @dataProvider provideExpressions
      */
     public function testExpandedWithItemOnly($expr)
     {
-
         /** @var EachToken $tok */
         list($tok) = $this->assertTokens("each \$item in $expr: p Some Text", [
             EachToken::class,
@@ -93,11 +93,11 @@ class EachScannerTest extends AbstractLexerTest
 
     /**
      * @covers ::scan
+     *
      * @dataProvider provideExpressions
      */
     public function testExpandedWithItemAndKey($expr)
     {
-
         /** @var EachToken $tok */
         list($tok) = $this->assertTokens("each \$someItem, \$someKey in $expr: p Some Text", [
             EachToken::class,
@@ -113,7 +113,9 @@ class EachScannerTest extends AbstractLexerTest
 
     /**
      * @dataProvider      provideInvalidSyntaxStyles
+     *
      * @covers            ::scan
+     *
      * @expectedException \Phug\LexerException
      */
     public function testThatItFailsWithInvalidSyntax($syntax)
@@ -124,7 +126,9 @@ class EachScannerTest extends AbstractLexerTest
 
     /**
      * @covers                   ::scan
+     *
      * @expectedException        \Phug\LexerException
+     *
      * @expectedExceptionMessage `each`-statement has no subject to operate on
      */
     public function testEachWithoutSubject()

--- a/tests/Phug/Lexer/Scanner/ForScannerTest.php
+++ b/tests/Phug/Lexer/Scanner/ForScannerTest.php
@@ -23,6 +23,7 @@ class ForScannerTest extends AbstractControlStatementScannerTest
      * @covers \Phug\Lexer\Scanner\ControlStatementScanner::scan
      * @covers \Phug\Lexer\Scanner\Partial\NamespaceAndTernaryTrait::checkForTernary
      * @covers \Phug\Lexer\Scanner\Partial\NamespaceAndTernaryTrait::checkForNamespaceAndTernary
+     *
      * @dataProvider provideExpressions
      */
     public function testExpandedExpressions($expr)

--- a/tests/Phug/Lexer/Scanner/IndentationScannerTest.php
+++ b/tests/Phug/Lexer/Scanner/IndentationScannerTest.php
@@ -166,6 +166,7 @@ class IndentationScannerTest extends AbstractLexerTest
      * @covers            \Phug\Lexer\Scanner\IndentationScanner::formatIndentChar
      * @covers            \Phug\Lexer\Scanner\IndentationScanner::getIndentChar
      * @covers            \Phug\LexerException::<public>
+     *
      * @expectedException \Phug\LexerException
      */
     public function testInconsistentIndent()
@@ -186,6 +187,7 @@ class IndentationScannerTest extends AbstractLexerTest
     /**
      * @covers            \Phug\Lexer\Scanner\IndentationScanner::formatIndentChar
      * @covers            \Phug\Lexer\Scanner\IndentationScanner::getIndentLevel
+     *
      * @expectedException \Phug\LexerException
      */
     public function testNotAllowedMixedIndent()

--- a/tests/Phug/Lexer/Scanner/WhenScannerTest.php
+++ b/tests/Phug/Lexer/Scanner/WhenScannerTest.php
@@ -26,6 +26,7 @@ class WhenScannerTest extends AbstractControlStatementScannerTest
      * @covers \Phug\Lexer\Scanner\ControlStatementScanner::scan
      * @covers \Phug\Lexer\Scanner\Partial\NamespaceAndTernaryTrait::checkForTernary
      * @covers \Phug\Lexer\Scanner\Partial\NamespaceAndTernaryTrait::checkForNamespaceAndTernary
+     *
      * @dataProvider provideExpressions
      */
     public function testExpandedExpressions($expr)
@@ -35,7 +36,6 @@ class WhenScannerTest extends AbstractControlStatementScannerTest
 
     public function testDefault()
     {
-
         /** @var WhenToken $tok */
         list($tok) = $this->assertTokens('default: p Do something', [
             WhenToken::class,

--- a/tests/Phug/Lexer/Scanner/WhileScannerTest.php
+++ b/tests/Phug/Lexer/Scanner/WhileScannerTest.php
@@ -23,6 +23,7 @@ class WhileScannerTest extends AbstractControlStatementScannerTest
      * @covers \Phug\Lexer\Scanner\ControlStatementScanner::scan
      * @covers \Phug\Lexer\Scanner\Partial\NamespaceAndTernaryTrait::checkForTernary
      * @covers \Phug\Lexer\Scanner\Partial\NamespaceAndTernaryTrait::checkForNamespaceAndTernary
+     *
      * @dataProvider provideExpressions
      */
     public function testExpandedExpressions($expr)

--- a/tests/Phug/Lexer/StateTest.php
+++ b/tests/Phug/Lexer/StateTest.php
@@ -20,7 +20,9 @@ class StateTest extends TestCase
 {
     /**
      * @covers                   ::__construct
+     *
      * @expectedException        \InvalidArgumentException
+     *
      * @expectedExceptionMessage Configuration option `reader_class_name`
      * @expectedExceptionMessage needs to be a valid FQCN of a class
      * @expectedExceptionMessage that extends Phug\Reader
@@ -71,7 +73,9 @@ class StateTest extends TestCase
 
     /**
      * @covers                   \Phug\Lexer\Partial\IndentStyleTrait::setIndentStyle
+     *
      * @expectedException        \InvalidArgumentException
+     *
      * @expectedExceptionMessage indentStyle needs to be null or one of the INDENT_* constants of the lexer
      */
     public function testSetIndentStyleException()
@@ -120,7 +124,9 @@ class StateTest extends TestCase
 
     /**
      * @covers                   \Phug\Lexer\Partial\IndentStyleTrait::setIndentWidth
+     *
      * @expectedException        \InvalidArgumentException
+     *
      * @expectedExceptionMessage indentWidth needs to be null or an integer above 0
      */
     public function testSetIndentWidthException()
@@ -143,7 +149,9 @@ class StateTest extends TestCase
     /**
      * @covers                   ::createToken
      * @covers                   ::throwException
+     *
      * @expectedException        \Phug\LexerException
+     *
      * @expectedExceptionMessage Failed to lex: bar
      * @expectedExceptionMessage Near: p Hello
      * @expectedExceptionMessage Line: 1
@@ -161,7 +169,9 @@ class StateTest extends TestCase
 
     /**
      * @covers                   ::__construct
+     *
      * @expectedException        \Phug\ReaderException
+     *
      * @expectedExceptionMessage Path: path.pug
      */
     public function testReaderExceptionWithPath()
@@ -203,7 +213,9 @@ class StateTest extends TestCase
      * @covers                   ::scan
      * @covers                   ::filterScanners
      * @covers                   ::throwException
+     *
      * @expectedException        \InvalidArgumentException
+     *
      * @expectedExceptionMessage The passed scanner with key `tag`
      * @expectedExceptionMessage doesn't seem to be either a valid
      * @expectedExceptionMessage Phug\Lexer\ScannerInterface
@@ -222,7 +234,9 @@ class StateTest extends TestCase
      * @covers                   ::scan
      * @covers                   ::filterScanners
      * @covers                   ::throwException
+     *
      * @expectedException        \Phug\LexerException
+     *
      * @expectedExceptionMessage Scanner Phug\Test\MockScanner
      * @expectedExceptionMessage generated a result that is not a
      * @expectedExceptionMessage Phug\Lexer\TokenInterface
@@ -245,7 +259,9 @@ class StateTest extends TestCase
     /**
      * @covers                   ::loopScan
      * @covers                   ::throwException
+     *
      * @expectedException        \Phug\LexerException
+     *
      * @expectedExceptionMessage Unexpected p Hello
      */
     public function testLoopScanException()

--- a/tests/Phug/LexerModuleTest.php
+++ b/tests/Phug/LexerModuleTest.php
@@ -244,7 +244,9 @@ class LexerModuleTest extends AbstractLexerTest
 
     /**
      * @covers                   \Phug\Lexer\Event\TokenEvent::setTokenGenerator
+     *
      * @expectedException        InvalidArgumentException
+     *
      * @expectedExceptionMessage setTokenGenerator(iterable $tokens) expect its argument to be iterable, integer received.
      */
     public function testTokenGeneratorBadInput()

--- a/tests/Phug/LexerTest.php
+++ b/tests/Phug/LexerTest.php
@@ -41,6 +41,7 @@ class LexerTest extends AbstractLexerTest
 
     /**
      * @covers            \Phug\Lexer\Partial\StateTrait::getState
+     *
      * @expectedException \RuntimeException
      */
     public function testGetStateException()
@@ -148,6 +149,7 @@ class LexerTest extends AbstractLexerTest
 
     /**
      * @covers            ::filterScanner
+     *
      * @expectedException \InvalidArgumentException
      */
     public function testFilterScanner()
@@ -165,6 +167,7 @@ class LexerTest extends AbstractLexerTest
 
     /**
      * @covers            ::lex
+     *
      * @expectedException \InvalidArgumentException
      */
     public function testBadStateClassName()

--- a/tests/Phug/OptimizerTest.php
+++ b/tests/Phug/OptimizerTest.php
@@ -88,7 +88,9 @@ class OptimizerTest extends AbstractPhugTest
 
     /**
      * @covers                   \Phug\Phug::cacheDirectory
+     *
      * @expectedException        \InvalidArgumentException
+     *
      * @expectedExceptionMessage Expected $options to be an array, got: 'biz'
      */
     public function testCacheDirectoryWithWrongOptions()

--- a/tests/Phug/Parser/StateTest.php
+++ b/tests/Phug/Parser/StateTest.php
@@ -142,7 +142,9 @@ class StateTest extends TestCase
 
     /**
      * @covers                   ::handleToken
+     *
      * @expectedException        \Phug\ParserException
+     *
      * @expectedExceptionMessage Failed to parse: Unexpected token
      * @expectedExceptionMessage `Phug\Lexer\Token\TagToken`,
      * @expectedExceptionMessage no token handler registered
@@ -387,7 +389,9 @@ class StateTest extends TestCase
 
     /**
      * @covers                   ::createNode
+     *
      * @expectedException        \InvalidArgumentException
+     *
      * @expectedExceptionMessage ErrorException is not a valid token class
      */
     public function testCreateNodeException()
@@ -447,7 +451,9 @@ class StateTest extends TestCase
 
     /**
      * @covers                   ::leave
+     *
      * @expectedException        \Phug\ParserException
+     *
      * @expectedExceptionMessage Failed to outdent: No parent to outdent to.
      * @expectedExceptionMessage Seems the parser moved out too many levels.
      */
@@ -495,7 +501,9 @@ class StateTest extends TestCase
 
     /**
      * @covers                   ::throwException
+     *
      * @expectedException        \Phug\ParserException
+     *
      * @expectedExceptionMessage Failed to parse: Unexpected token
      * @expectedExceptionMessage `Phug\Lexer\Token\TagToken`,
      * @expectedExceptionMessage no token handler registered

--- a/tests/Phug/Parser/TokenHandler/AssignmentTokenHandlerTest.php
+++ b/tests/Phug/Parser/TokenHandler/AssignmentTokenHandlerTest.php
@@ -73,7 +73,9 @@ class AssignmentTokenHandlerTest extends TestCase
 
     /**
      * @covers                   ::<public>
+     *
      * @expectedException        \RuntimeException
+     *
      * @expectedExceptionMessage You can only pass Assignment tokens to this token handler
      */
     public function testHandleTokenTokenException()
@@ -86,7 +88,9 @@ class AssignmentTokenHandlerTest extends TestCase
 
     /**
      * @covers                   ::<public>
+     *
      * @expectedException        \Phug\ParserException
+     *
      * @expectedExceptionMessage Failed to parse: Assignments can only happen on elements and mixinCalls
      */
     public function testHandleTokenElementTagsException()

--- a/tests/Phug/Parser/TokenHandler/AttributeEndTokenHandlerTest.php
+++ b/tests/Phug/Parser/TokenHandler/AttributeEndTokenHandlerTest.php
@@ -30,7 +30,9 @@ class AttributeEndTokenHandlerTest extends TestCase
 
     /**
      * @covers                   ::<public>
+     *
      * @expectedException        \RuntimeException
+     *
      * @expectedExceptionMessage You can only pass attribute end tokens to this token handler
      */
     public function testHandleTokenTokenException()

--- a/tests/Phug/Parser/TokenHandler/AttributeStartTokenHandlerTest.php
+++ b/tests/Phug/Parser/TokenHandler/AttributeStartTokenHandlerTest.php
@@ -64,7 +64,9 @@ class AttributeStartTokenHandlerTest extends AbstractParserTest
     /**
      * @covers                   ::<public>
      * @covers                   Phug\Parser\TokenHandler\AttributeStartTokenHandler::<public>
+     *
      * @expectedException        \RuntimeException
+     *
      * @expectedExceptionMessage You can only pass attribute start tokens to this token handler
      */
     public function testHandleTokenTokenException()
@@ -78,7 +80,9 @@ class AttributeStartTokenHandlerTest extends AbstractParserTest
     /**
      * @covers                   ::<public>
      * @covers                   \Phug\Parser\TokenHandler\AttributeStartTokenHandler::<public>
+     *
      * @expectedException        \Phug\ParserException
+     *
      * @expectedExceptionMessage Failed to parse: Attributes can only be placed on
      * @expectedExceptionMessage element, assignment, import, variable,
      * @expectedExceptionMessage mixin and mixinCall
@@ -101,7 +105,9 @@ class AttributeStartTokenHandlerTest extends AbstractParserTest
     /**
      * @covers                   ::<public>
      * @covers                   \Phug\Parser\TokenHandler\AttributeStartTokenHandler::<public>
+     *
      * @expectedException        \Phug\ParserException
+     *
      * @expectedExceptionMessage Attribute list not closed
      */
     public function testHandleTokenListNotClosedException()

--- a/tests/Phug/Parser/TokenHandler/AttributeTokenHandlerTest.php
+++ b/tests/Phug/Parser/TokenHandler/AttributeTokenHandlerTest.php
@@ -47,7 +47,9 @@ class AttributeTokenHandlerTest extends AbstractParserTest
 
     /**
      * @covers                   ::<public>
+     *
      * @expectedException        \RuntimeException
+     *
      * @expectedExceptionMessage You can only pass attribute tokens to this token handler
      */
     public function testHandleTokenTokenException()

--- a/tests/Phug/Parser/TokenHandler/AutoCloseTokenHandlerTest.php
+++ b/tests/Phug/Parser/TokenHandler/AutoCloseTokenHandlerTest.php
@@ -89,7 +89,9 @@ class AutoCloseTokenHandlerTest extends AbstractParserTest
 
     /**
      * @covers                   ::<public>
+     *
      * @expectedException        \RuntimeException
+     *
      * @expectedExceptionMessage You can only pass auto-close tokens to this token handler
      */
     public function testHandleTokenTokenException()
@@ -102,7 +104,9 @@ class AutoCloseTokenHandlerTest extends AbstractParserTest
 
     /**
      * @covers                   ::<public>
+     *
      * @expectedException        \Phug\ParserException
+     *
      * @expectedExceptionMessage Auto-close operators can only be used on elements
      */
     public function testHandleClassOnWrongNode()

--- a/tests/Phug/Parser/TokenHandler/BlockTokenHandlerTest.php
+++ b/tests/Phug/Parser/TokenHandler/BlockTokenHandlerTest.php
@@ -27,7 +27,9 @@ class BlockTokenHandlerTest extends AbstractParserTest
 
     /**
      * @covers                   ::<public>
+     *
      * @expectedException        \RuntimeException
+     *
      * @expectedExceptionMessage You can only pass block tokens to this token handler
      */
     public function testHandleTokenTokenException()

--- a/tests/Phug/Parser/TokenHandler/CaseTokenHandlerTest.php
+++ b/tests/Phug/Parser/TokenHandler/CaseTokenHandlerTest.php
@@ -27,7 +27,9 @@ class CaseTokenHandlerTest extends AbstractParserTest
 
     /**
      * @covers                   ::<public>
+     *
      * @expectedException        \RuntimeException
+     *
      * @expectedExceptionMessage You can only pass case tokens to this token handler
      */
     public function testHandleTokenTokenException()

--- a/tests/Phug/Parser/TokenHandler/ClassTokenHandlerTest.php
+++ b/tests/Phug/Parser/TokenHandler/ClassTokenHandlerTest.php
@@ -50,7 +50,9 @@ class ClassTokenHandlerTest extends AbstractParserTest
 
     /**
      * @covers                   ::<public>
+     *
      * @expectedException        \RuntimeException
+     *
      * @expectedExceptionMessage You can only pass class tokens to this token handler
      */
     public function testHandleTokenTokenException()
@@ -63,7 +65,9 @@ class ClassTokenHandlerTest extends AbstractParserTest
 
     /**
      * @covers                   ::<public>
+     *
      * @expectedException        \Phug\ParserException
+     *
      * @expectedExceptionMessage Classes can only be used on elements and mixin calls
      */
     public function testHandleClassOnWrongNode()

--- a/tests/Phug/Parser/TokenHandler/CodeTokenHandlerTest.php
+++ b/tests/Phug/Parser/TokenHandler/CodeTokenHandlerTest.php
@@ -98,7 +98,9 @@ class CodeTokenHandlerTest extends AbstractParserTest
 
     /**
      * @covers                   ::<public>
+     *
      * @expectedException        \RuntimeException
+     *
      * @expectedExceptionMessage You can only pass code tokens to this token handler
      */
     public function testHandleTokenTokenException()
@@ -112,7 +114,9 @@ class CodeTokenHandlerTest extends AbstractParserTest
     /**
      * @covers                   ::<public>
      * @covers                   \Phug\Parser\State::throwException
+     *
      * @expectedException        \Phug\ParserException
+     *
      * @expectedExceptionMessage Unexpected token `blockcode` expected `text`, `interpolated-code` or `code`
      */
     public function testHandleTokenUnexpectedBlock()

--- a/tests/Phug/Parser/TokenHandler/CommentTokenHandlerTest.php
+++ b/tests/Phug/Parser/TokenHandler/CommentTokenHandlerTest.php
@@ -40,7 +40,9 @@ class CommentTokenHandlerTest extends AbstractParserTest
 
     /**
      * @covers                   ::<public>
+     *
      * @expectedException        \RuntimeException
+     *
      * @expectedExceptionMessage You can only pass comment tokens to this token handler
      */
     public function testHandleTokenTokenException()

--- a/tests/Phug/Parser/TokenHandler/ConditionalTokenHandlerTest.php
+++ b/tests/Phug/Parser/TokenHandler/ConditionalTokenHandlerTest.php
@@ -28,7 +28,9 @@ class ConditionalTokenHandlerTest extends AbstractParserTest
 
     /**
      * @covers                   ::<public>
+     *
      * @expectedException        \RuntimeException
+     *
      * @expectedExceptionMessage You can only pass conditional tokens to this token handler
      */
     public function testHandleTokenTokenException()

--- a/tests/Phug/Parser/TokenHandler/DoTokenHandlerTest.php
+++ b/tests/Phug/Parser/TokenHandler/DoTokenHandlerTest.php
@@ -32,7 +32,9 @@ class DoTokenHandlerTest extends AbstractParserTest
 
     /**
      * @covers                   ::<public>
+     *
      * @expectedException        \RuntimeException
+     *
      * @expectedExceptionMessage You can only pass do tokens to this token handler
      */
     public function testHandleTokenTokenException()

--- a/tests/Phug/Parser/TokenHandler/DoctypeTokenHandlerTest.php
+++ b/tests/Phug/Parser/TokenHandler/DoctypeTokenHandlerTest.php
@@ -27,7 +27,9 @@ class DoctypeTokenHandlerTest extends AbstractParserTest
 
     /**
      * @covers                   ::<public>
+     *
      * @expectedException        \RuntimeException
+     *
      * @expectedExceptionMessage You can only pass doctype tokens to this token handler
      */
     public function testHandleTokenTokenException()

--- a/tests/Phug/Parser/TokenHandler/EachTokenHandlerTest.php
+++ b/tests/Phug/Parser/TokenHandler/EachTokenHandlerTest.php
@@ -29,7 +29,9 @@ class EachTokenHandlerTest extends AbstractParserTest
 
     /**
      * @covers                   ::<public>
+     *
      * @expectedException        \RuntimeException
+     *
      * @expectedExceptionMessage You can only pass each tokens to this token handler
      */
     public function testHandleTokenTokenException()

--- a/tests/Phug/Parser/TokenHandler/ExpansionTokenHandlerTest.php
+++ b/tests/Phug/Parser/TokenHandler/ExpansionTokenHandlerTest.php
@@ -74,7 +74,9 @@ class ExpansionTokenHandlerTest extends AbstractParserTest
 
     /**
      * @covers                   ::<public>
+     *
      * @expectedException        \RuntimeException
+     *
      * @expectedExceptionMessage You can only pass expansion tokens to this token handler
      */
     public function testHandleTokenTokenException()

--- a/tests/Phug/Parser/TokenHandler/ExpressionTokenHandlerTest.php
+++ b/tests/Phug/Parser/TokenHandler/ExpressionTokenHandlerTest.php
@@ -33,7 +33,9 @@ class ExpressionTokenHandlerTest extends AbstractParserTest
 
     /**
      * @covers                   ::<public>
+     *
      * @expectedException        \RuntimeException
+     *
      * @expectedExceptionMessage You can only pass expression tokens to this token handler
      */
     public function testHandleTokenTokenException()

--- a/tests/Phug/Parser/TokenHandler/FilterTokenHandlerTest.php
+++ b/tests/Phug/Parser/TokenHandler/FilterTokenHandlerTest.php
@@ -89,7 +89,9 @@ class FilterTokenHandlerTest extends AbstractParserTest
 
     /**
      * @covers                   ::<public>
+     *
      * @expectedException        \RuntimeException
+     *
      * @expectedExceptionMessage You can only pass filter tokens to this token handler
      */
     public function testHandleTokenTokenException()

--- a/tests/Phug/Parser/TokenHandler/ForTokenHandlerTest.php
+++ b/tests/Phug/Parser/TokenHandler/ForTokenHandlerTest.php
@@ -29,7 +29,9 @@ class ForTokenHandlerTest extends AbstractParserTest
 
     /**
      * @covers                   ::<public>
+     *
      * @expectedException        \RuntimeException
+     *
      * @expectedExceptionMessage You can only pass for tokens to this token handler
      */
     public function testHandleTokenTokenException()

--- a/tests/Phug/Parser/TokenHandler/IdTokenHandlerTest.php
+++ b/tests/Phug/Parser/TokenHandler/IdTokenHandlerTest.php
@@ -37,7 +37,9 @@ class IdTokenHandlerTest extends AbstractParserTest
 
     /**
      * @covers                   ::<public>
+     *
      * @expectedException        \RuntimeException
+     *
      * @expectedExceptionMessage You can only pass id tokens to this token handler
      */
     public function testHandleTokenTokenException()
@@ -50,7 +52,9 @@ class IdTokenHandlerTest extends AbstractParserTest
 
     /**
      * @covers                   ::<public>
+     *
      * @expectedException        \Phug\ParserException
+     *
      * @expectedExceptionMessage IDs can only be used on elements and mixin calls
      */
     public function testHandleTokenElementException()

--- a/tests/Phug/Parser/TokenHandler/ImportTokenHandlerTest.php
+++ b/tests/Phug/Parser/TokenHandler/ImportTokenHandlerTest.php
@@ -38,7 +38,9 @@ class ImportTokenHandlerTest extends AbstractParserTest
 
     /**
      * @covers                   ::<public>
+     *
      * @expectedException        \RuntimeException
+     *
      * @expectedExceptionMessage You can only pass import tokens to this token handler
      */
     public function testHandleTokenTokenException()
@@ -52,7 +54,9 @@ class ImportTokenHandlerTest extends AbstractParserTest
     /**
      * @covers                   ::<public>
      * @covers                   ::isEmptyDocument
+     *
      * @expectedException        \Phug\ParserException
+     *
      * @expectedExceptionMessage extends should be the very first statement in a document
      */
     public function testDivTagBeforeExtends()
@@ -63,7 +67,9 @@ class ImportTokenHandlerTest extends AbstractParserTest
     /**
      * @covers                   ::<public>
      * @covers                   ::isEmptyDocument
+     *
      * @expectedException        \Phug\ParserException
+     *
      * @expectedExceptionMessage extends should be the very first statement in a document
      */
     public function testVisibleCommentBeforeExtends()
@@ -74,7 +80,9 @@ class ImportTokenHandlerTest extends AbstractParserTest
     /**
      * @covers                   ::<public>
      * @covers                   ::isEmptyDocument
+     *
      * @expectedException        \Phug\ParserException
+     *
      * @expectedExceptionMessage extends should be the very first statement in a document
      */
     public function testMultipleThingsBeforeExtends()

--- a/tests/Phug/Parser/TokenHandler/IndentTokenHandlerTest.php
+++ b/tests/Phug/Parser/TokenHandler/IndentTokenHandlerTest.php
@@ -29,7 +29,9 @@ class IndentTokenHandlerTest extends AbstractParserTest
 
     /**
      * @covers                   ::<public>
+     *
      * @expectedException        \RuntimeException
+     *
      * @expectedExceptionMessage You can only pass indent tokens to this token handler
      */
     public function testHandleTokenTokenException()

--- a/tests/Phug/Parser/TokenHandler/InterpolationEndTokenHandlerTest.php
+++ b/tests/Phug/Parser/TokenHandler/InterpolationEndTokenHandlerTest.php
@@ -16,7 +16,9 @@ class InterpolationEndTokenHandlerTest extends TestCase
 {
     /**
      * @covers                   ::<public>
+     *
      * @expectedException        \RuntimeException
+     *
      * @expectedExceptionMessage You can only pass interpolation end tokens to this token handler
      */
     public function testHandleTokenTokenException()

--- a/tests/Phug/Parser/TokenHandler/InterpolationStartTokenHandlerTest.php
+++ b/tests/Phug/Parser/TokenHandler/InterpolationStartTokenHandlerTest.php
@@ -127,7 +127,9 @@ class InterpolationStartTokenHandlerTest extends AbstractParserTest
 
     /**
      * @covers                   ::<public>
+     *
      * @expectedException        \RuntimeException
+     *
      * @expectedExceptionMessage You can only pass interpolation start tokens to this token handler
      */
     public function testHandleTokenTokenException()
@@ -207,7 +209,9 @@ class InterpolationStartTokenHandlerTest extends AbstractParserTest
 
     /**
      * @covers                   ::<public>
+     *
      * @expectedException        \Phug\ParserException
+     *
      * @expectedExceptionMessage Interpolation not properly closed
      */
     public function testBadEndingException()

--- a/tests/Phug/Parser/TokenHandler/KeywordTokenHandlerTest.php
+++ b/tests/Phug/Parser/TokenHandler/KeywordTokenHandlerTest.php
@@ -43,7 +43,9 @@ class KeywordTokenHandlerTest extends AbstractParserTest
 
     /**
      * @covers                   ::<public>
+     *
      * @expectedException        \RuntimeException
+     *
      * @expectedExceptionMessage You can only pass keyword tokens to this token handler
      */
     public function testHandleTokenTokenException()

--- a/tests/Phug/Parser/TokenHandler/MixinCallTokenHandlerTest.php
+++ b/tests/Phug/Parser/TokenHandler/MixinCallTokenHandlerTest.php
@@ -39,7 +39,9 @@ class MixinCallTokenHandlerTest extends AbstractParserTest
 
     /**
      * @covers                   ::<public>
+     *
      * @expectedException        \RuntimeException
+     *
      * @expectedExceptionMessage You can only pass mixin call tokens to this token handler
      */
     public function testHandleTokenTokenException()

--- a/tests/Phug/Parser/TokenHandler/MixinTokenHandlerTest.php
+++ b/tests/Phug/Parser/TokenHandler/MixinTokenHandlerTest.php
@@ -29,7 +29,9 @@ class MixinTokenHandlerTest extends AbstractParserTest
 
     /**
      * @covers                   ::<public>
+     *
      * @expectedException        \RuntimeException
+     *
      * @expectedExceptionMessage You can only pass mixin tokens to this token handler
      */
     public function testHandleTokenTokenException()

--- a/tests/Phug/Parser/TokenHandler/NewLineTokenHandlerTest.php
+++ b/tests/Phug/Parser/TokenHandler/NewLineTokenHandlerTest.php
@@ -31,7 +31,9 @@ class NewLineTokenHandlerTest extends AbstractParserTest
 
     /**
      * @covers                   ::<public>
+     *
      * @expectedException        \RuntimeException
+     *
      * @expectedExceptionMessage You can only pass newline tokens to this token handler
      */
     public function testHandleTokenTokenException()

--- a/tests/Phug/Parser/TokenHandler/OutdentTokenHandlerTest.php
+++ b/tests/Phug/Parser/TokenHandler/OutdentTokenHandlerTest.php
@@ -31,7 +31,9 @@ class OutdentTokenHandlerTest extends AbstractParserTest
 
     /**
      * @covers                   ::<public>
+     *
      * @expectedException        \RuntimeException
+     *
      * @expectedExceptionMessage You can only pass outdent tokens to this token handler
      */
     public function testHandleTokenTokenException()

--- a/tests/Phug/Parser/TokenHandler/TagInterpolationEndTokenHandlerTest.php
+++ b/tests/Phug/Parser/TokenHandler/TagInterpolationEndTokenHandlerTest.php
@@ -16,7 +16,9 @@ class TagInterpolationEndTokenHandlerTest extends TestCase
 {
     /**
      * @covers                   ::<public>
+     *
      * @expectedException        \RuntimeException
+     *
      * @expectedExceptionMessage You can only pass tag interpolation end tokens to this token handler
      */
     public function testHandleTokenTokenException()

--- a/tests/Phug/Parser/TokenHandler/TagInterpolationStartTokenHandlerTest.php
+++ b/tests/Phug/Parser/TokenHandler/TagInterpolationStartTokenHandlerTest.php
@@ -127,7 +127,9 @@ class TagInterpolationStartTokenHandlerTest extends AbstractParserTest
 
     /**
      * @covers                   ::<public>
+     *
      * @expectedException        \RuntimeException
+     *
      * @expectedExceptionMessage You can only pass tag interpolation start tokens to this token handler
      */
     public function testHandleTokenTokenException()

--- a/tests/Phug/Parser/TokenHandler/TagTokenHandlerTest.php
+++ b/tests/Phug/Parser/TokenHandler/TagTokenHandlerTest.php
@@ -50,7 +50,9 @@ class TagTokenHandlerTest extends AbstractParserTest
 
     /**
      * @covers                   ::<public>
+     *
      * @expectedException        \RuntimeException
+     *
      * @expectedExceptionMessage You can only pass tag tokens to this token handler
      */
     public function testHandleTokenTokenException()
@@ -63,7 +65,9 @@ class TagTokenHandlerTest extends AbstractParserTest
 
     /**
      * @covers                   ::<public>
+     *
      * @expectedException        \Phug\ParserException
+     *
      * @expectedExceptionMessage Failed to parse: Tags can only be used on elements
      */
     public function testHandleTokenElementTagsException()
@@ -83,7 +87,9 @@ class TagTokenHandlerTest extends AbstractParserTest
 
     /**
      * @covers                   ::<public>
+     *
      * @expectedException        \Phug\ParserException
+     *
      * @expectedExceptionMessage Failed to parse: The element already has a tag name
      */
     public function testHandleTokenTagNameException()

--- a/tests/Phug/Parser/TokenHandler/TextTokenHandlerTest.php
+++ b/tests/Phug/Parser/TokenHandler/TextTokenHandlerTest.php
@@ -60,7 +60,9 @@ class TextTokenHandlerTest extends AbstractParserTest
 
     /**
      * @covers                   ::<public>
+     *
      * @expectedException        \RuntimeException
+     *
      * @expectedExceptionMessage You can only pass text tokens to this token handler
      */
     public function testHandleTokenTokenException()

--- a/tests/Phug/Parser/TokenHandler/VariableTokenHandlerTest.php
+++ b/tests/Phug/Parser/TokenHandler/VariableTokenHandlerTest.php
@@ -28,7 +28,9 @@ class VariableTokenHandlerTest extends AbstractParserTest
 
     /**
      * @covers                   ::<public>
+     *
      * @expectedException        \RuntimeException
+     *
      * @expectedExceptionMessage You can only pass variable tokens to this token handler
      */
     public function testHandleTokenTokenException()

--- a/tests/Phug/Parser/TokenHandler/WhenTokenHandlerTest.php
+++ b/tests/Phug/Parser/TokenHandler/WhenTokenHandlerTest.php
@@ -50,7 +50,9 @@ class WhenTokenHandlerTest extends AbstractParserTest
 
     /**
      * @covers                   ::<public>
+     *
      * @expectedException        \RuntimeException
+     *
      * @expectedExceptionMessage You can only pass when tokens to this token handler
      */
     public function testHandleTokenTokenException()

--- a/tests/Phug/Parser/TokenHandler/WhileTokenHandlerTest.php
+++ b/tests/Phug/Parser/TokenHandler/WhileTokenHandlerTest.php
@@ -45,7 +45,9 @@ class WhileTokenHandlerTest extends AbstractParserTest
 
     /**
      * @covers                   ::<public>
+     *
      * @expectedException        \RuntimeException
+     *
      * @expectedExceptionMessage You can only pass while tokens to this token handler
      */
     public function testHandleTokenTokenException()

--- a/tests/Phug/Parser/TokenHandler/YieldTokenHandlerTest.php
+++ b/tests/Phug/Parser/TokenHandler/YieldTokenHandlerTest.php
@@ -27,7 +27,9 @@ class YieldTokenHandlerTest extends AbstractParserTest
 
     /**
      * @covers                   ::<public>
+     *
      * @expectedException        \RuntimeException
+     *
      * @expectedExceptionMessage You can only pass yield tokens to this token handler
      */
     public function testHandleTokenTokenException()

--- a/tests/Phug/ParserModuleTest.php
+++ b/tests/Phug/ParserModuleTest.php
@@ -109,6 +109,7 @@ class ParserModuleTest extends AbstractParserTest
 
     /**
      * @group events
+     *
      * @covers \Phug\Parser::__construct
      * @covers \Phug\Parser\Event\ParseEvent::<public>
      * @covers \Phug\Parser\Event\NodeEvent::<public>

--- a/tests/Phug/ParserTest.php
+++ b/tests/Phug/ParserTest.php
@@ -22,7 +22,9 @@ class ParserTest extends AbstractParserTest
 
     /**
      * @covers                   ::<public>
+     *
      * @expectedException        \InvalidArgumentException
+     *
      * @expectedExceptionMessage Passed lexer class ErrorException is not a valid Phug\Lexer
      */
     public function testWrongLexerClassNameOption()
@@ -34,7 +36,9 @@ class ParserTest extends AbstractParserTest
 
     /**
      * @covers                   ::<public>
+     *
      * @expectedException        \InvalidArgumentException
+     *
      * @expectedExceptionMessage Passed token handler needs to implement Phug\Parser\TokenHandlerInterface
      */
     public function testWrongTokenHandler()
@@ -45,7 +49,9 @@ class ParserTest extends AbstractParserTest
     /**
      * @covers                   ::<public>
      * @covers                   ::dumpNode
+     *
      * @expectedException        \InvalidArgumentException
+     *
      * @expectedExceptionMessage parser_state_class_name needs to be a valid Phug\Parser\State sub class
      */
     public function testWrongStateClassNameOption()

--- a/tests/Phug/PhugTest.php
+++ b/tests/Phug/PhugTest.php
@@ -258,7 +258,9 @@ class PhugTest extends AbstractPhugTest
 
     /**
      * @covers                   ::setFilter
+     *
      * @expectedException        \Phug\PhugException
+     *
      * @expectedExceptionMessage Invalid foo filter given:
      */
     public function testWrongFilter()
@@ -297,7 +299,9 @@ class PhugTest extends AbstractPhugTest
 
     /**
      * @covers                   ::addExtension
+     *
      * @expectedException        \Phug\PhugException
+     *
      * @expectedExceptionMessage Invalid not-an-extension extension given:
      */
     public function testWrongExtension()

--- a/tests/Phug/ProfilerModuleTest.php
+++ b/tests/Phug/ProfilerModuleTest.php
@@ -187,6 +187,7 @@ class ProfilerModuleTest extends TestCase
      * @covers ::renderProfile
      * @covers ::recordDisplayEvent
      * @covers ::getException
+     * @covers \Phug\Renderer\Partial\Debug\DebuggerTrait::getRendererException
      */
     public function testExecutionMaxTime()
     {

--- a/tests/Phug/ProfilerModuleTest.php
+++ b/tests/Phug/ProfilerModuleTest.php
@@ -19,6 +19,7 @@ class ProfilerModuleTest extends TestCase
 {
     /**
      * @group profiler
+     *
      * @covers ::record
      * @covers ::renderProfile
      * @covers ::cleanupProfilerNodes
@@ -88,6 +89,7 @@ class ProfilerModuleTest extends TestCase
 
     /**
      * @group profiler
+     *
      * @covers ::record
      * @covers ::renderProfile
      * @covers ::recordDisplayEvent
@@ -129,6 +131,7 @@ class ProfilerModuleTest extends TestCase
 
     /**
      * @group profiler
+     *
      * @covers ::renderProfile
      * @covers \Phug\Renderer\Partial\Debug\DebuggerTrait::initDebugOptions
      */
@@ -151,6 +154,7 @@ class ProfilerModuleTest extends TestCase
 
     /**
      * @group profiler
+     *
      * @covers ::renderProfile
      * @covers \Phug\Renderer\Partial\Debug\DebuggerTrait::initDebugOptions
      */
@@ -178,6 +182,7 @@ class ProfilerModuleTest extends TestCase
 
     /**
      * @group profiler
+     *
      * @covers ::record
      * @covers ::renderProfile
      * @covers ::recordDisplayEvent
@@ -216,6 +221,7 @@ class ProfilerModuleTest extends TestCase
 
     /**
      * @group profiler
+     *
      * @covers ::record
      * @covers ::renderProfile
      * @covers ::recordDisplayEvent
@@ -265,6 +271,7 @@ class ProfilerModuleTest extends TestCase
 
     /**
      * @group profiler
+     *
      * @covers \Phug\Renderer\Profiler\TokenDump::<public>
      */
     public function testTokenDump()
@@ -294,6 +301,7 @@ class ProfilerModuleTest extends TestCase
 
     /**
      * @group profiler
+     *
      * @covers ::record
      * @covers ::renderProfile
      * @covers ::cleanupProfilerNodes
@@ -347,6 +355,7 @@ class ProfilerModuleTest extends TestCase
 
     /**
      * @group profiler
+     *
      * @covers ::reset
      * @covers ::initialize
      * @covers ::getFunctionDump
@@ -396,6 +405,7 @@ class ProfilerModuleTest extends TestCase
 
     /**
      * @group profiler
+     *
      * @covers ::reset
      * @covers ::initialize
      * @covers ::getFunctionDump
@@ -451,6 +461,7 @@ class ProfilerModuleTest extends TestCase
 
     /**
      * @group profiler
+     *
      * @covers ::initialize
      * @covers ::getFunctionDump
      */

--- a/tests/Phug/ReaderTest.php
+++ b/tests/Phug/ReaderTest.php
@@ -198,6 +198,7 @@ class ReaderTest extends TestCase
 
     /**
      * @covers ::peek
+     *
      * @expectedException \InvalidArgumentException
      */
     public function testPeekThrowsExceptionOnInvalidArguments()
@@ -236,6 +237,7 @@ class ReaderTest extends TestCase
      * @covers ::getPregErrorText
      * @covers ::throwException
      * @covers \Phug\ReaderException
+     *
      * @expectedException \Phug\ReaderException
      */
     public function testMatchFailsOnPregError()
@@ -246,7 +248,9 @@ class ReaderTest extends TestCase
     /**
      * @covers ::throwException
      * @covers \Phug\ReaderException
+     *
      * @expectedException \Phug\ReaderException
+     *
      * @expectedExceptionMessage Path: path.pug
      */
     public function testPathInErrors()
@@ -275,6 +279,7 @@ class ReaderTest extends TestCase
      * @covers ::getMatch
      * @covers ::throwException
      * @covers \Phug\ReaderException
+     *
      * @expectedException \Phug\ReaderException
      */
     public function testGetMatchCantOperateOnMissingMatchCall()
@@ -297,6 +302,7 @@ class ReaderTest extends TestCase
      * @covers ::getMatchData
      * @covers ::throwException
      * @covers \Phug\ReaderException
+     *
      * @expectedException \Phug\ReaderException
      */
     public function testGetMatchDataCantOperateOnMissingMatchCall()
@@ -336,6 +342,7 @@ class ReaderTest extends TestCase
      * @covers ::consume
      * @covers ::throwException
      * @covers \Phug\ReaderException
+     *
      * @expectedException \Phug\ReaderException
      */
     public function testConsumeThrowsExceptionOnInvalidConsumeLength()
@@ -361,6 +368,7 @@ class ReaderTest extends TestCase
 
     /**
      * @covers ::readWhile
+     *
      * @expectedException \InvalidArgumentException
      */
     public function testReadWhileExpectsValidCallback()
@@ -659,6 +667,7 @@ class ReaderTest extends TestCase
      * @covers ::readString
      * @covers ::throwException
      * @covers \Phug\ReaderException
+     *
      * @expectedException \Phug\ReaderException
      *
      * @dataProvider provideNotCorrectlyClosedStrings
@@ -692,6 +701,7 @@ class ReaderTest extends TestCase
      * @covers ::readExpression
      * @covers ::throwException
      * @covers \Phug\ReaderException
+     *
      * @expectedException \Phug\ReaderException
      *
      * @dataProvider provideNotCorrectlyClosedBrackets
@@ -726,7 +736,6 @@ class ReaderTest extends TestCase
 
     public function testReadmeFirstLexingExample()
     {
-
         //Some C-style example code
         $code = 'someVar = {a, "this is a string (really, it \"is\")", func(b, c), d}';
 

--- a/tests/Phug/RendererTest.php
+++ b/tests/Phug/RendererTest.php
@@ -1283,10 +1283,6 @@ class RendererTest extends AbstractRendererTest
      */
     public function testCacheDirectoryPreserveDependencies()
     {
-        if (version_compare(PHP_VERSION, '8.1.0-dev', '>=')) {
-            $this->markTestSkipped('Not compatible with PHP 8.1');
-        }
-
         $cacheDirectory = sys_get_temp_dir().'/pug-test'.mt_rand(0, 999999);
         $this->createEmptyDirectory($cacheDirectory);
 

--- a/tests/Phug/RendererTest.php
+++ b/tests/Phug/RendererTest.php
@@ -822,6 +822,7 @@ class RendererTest extends AbstractRendererTest
 
     /**
      * @group error
+     *
      * @covers ::handleError
      * @covers \Phug\Renderer\Partial\AdapterTrait::getSandboxCall
      * @covers \Phug\Renderer\Partial\AdapterTrait::handleHtmlEvent
@@ -1099,6 +1100,7 @@ class RendererTest extends AbstractRendererTest
 
     /**
      * @expectedException        Exception
+     *
      * @expectedExceptionMessage p= $undefined()
      */
     public function testExtendsUndefinedCall()
@@ -1120,6 +1122,7 @@ class RendererTest extends AbstractRendererTest
 
     /**
      * @expectedException        Exception
+     *
      * @expectedExceptionMessage div= $undefined()
      */
     public function testUndefinedCallInBlock()

--- a/tests/Phug/Util/AssociativeStorageTest.php
+++ b/tests/Phug/Util/AssociativeStorageTest.php
@@ -21,7 +21,9 @@ class AssociativeStorageTest extends TestCase
     /**
      * @covers                   ::<public>
      * @covers                   ::attachStrictMode
+     *
      * @expectedException        \InvalidArgumentException
+     *
      * @expectedExceptionMessage Duplicate entity for the name foo
      */
     public function testStrictMode()
@@ -39,7 +41,9 @@ class AssociativeStorageTest extends TestCase
     /**
      * @covers                   ::<public>
      * @covers                   ::attachStrictMode
+     *
      * @expectedException        \InvalidArgumentException
+     *
      * @expectedExceptionMessage Unknown mode: 99
      */
     public function testWrongMode()

--- a/tests/Phug/Util/AttributesStorageTest.php
+++ b/tests/Phug/Util/AttributesStorageTest.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace Phug\Test\Util;
+
+use PHPUnit\Framework\TestCase;
+use Phug\Formatter\Element\MarkupElement;
+use Phug\Util\AttributesStorage;
+use Phug\Util\OrderedValue;
+use SplObjectStorage;
+
+/**
+ * @coversDefaultClass \Phug\Util\AttributesStorage
+ */
+class AttributesStorageTest extends TestCase
+{
+    /**
+     * @covers ::__construct
+     * @covers ::attach
+     * @covers ::addAll
+     */
+    public function testNoHolder()
+    {
+        $storage = new AttributesStorage(null);
+        $storage->attach(new OrderedValue(42, null));
+        $next = new SplObjectStorage();
+        $next->attach(new OrderedValue('C', 3));
+        $next->attach(new OrderedValue('A', 1));
+        $storage->addAll($next);
+
+        $output = [];
+
+        foreach ($storage as $value) {
+            $output[] = [$value->getOrder(), $value->getValue()];
+        }
+
+        self::assertSame([
+            [null, 42],
+            [3, 'C'],
+            [1, 'A'],
+        ], $output);
+    }
+
+    /**
+     * @covers ::__construct
+     * @covers ::attach
+     * @covers ::addAll
+     */
+    public function testMarkupHolder()
+    {
+        $storage = new AttributesStorage(new MarkupElement('div'));
+        $storage->attach(new OrderedValue(42, null));
+        $next = new SplObjectStorage();
+        $next->attach(new OrderedValue('C', -3));
+        $next->attach(new OrderedValue('A', null));
+        $storage->addAll($next);
+
+        $output = [];
+
+        foreach ($storage as $value) {
+            $output[] = [$value->getOrder(), $value->getValue()];
+        }
+
+        self::assertSame([
+            [0, 42],
+            [-3, 'C'],
+            [1, 'A'],
+        ], $output);
+    }
+}

--- a/tests/Phug/Util/MacroableTraitTest.php
+++ b/tests/Phug/Util/MacroableTraitTest.php
@@ -130,7 +130,9 @@ class MacroableTraitTest extends TestCase
 
     /**
      * @covers                   \Phug\Util\Partial\MacroableTrait::__call
+     *
      * @expectedException        \BadMethodCallException
+     *
      * @expectedExceptionMessage Method fooBar does not exist.
      */
     public function testMacroCallBadMethod()
@@ -141,7 +143,9 @@ class MacroableTraitTest extends TestCase
 
     /**
      * @covers                   \Phug\Util\Partial\MacroableTrait::__callStatic
+     *
      * @expectedException        \BadMethodCallException
+     *
      * @expectedExceptionMessage Method fooBar does not exist.
      */
     public function testMacroCallStaticBadMethod()

--- a/tests/Phug/Util/ModuleContainerTest.php
+++ b/tests/Phug/Util/ModuleContainerTest.php
@@ -100,7 +100,9 @@ class ModuleContainerTest extends TestCase
     /**
      * @covers ::getModuleBaseClassName
      * @covers ::addModule
+     *
      * @expectedException InvalidArgumentException
+     *
      * @expectedExceptionMessage Passed module class name stdClass needs to be a class extending Phug\Util\ModuleInterface and/or Phug\Util\ModuleInterface
      */
     public function testInvalidModuleClassName()
@@ -115,7 +117,9 @@ class ModuleContainerTest extends TestCase
     /**
      * @covers ::getModuleBaseClassName
      * @covers ::addModule
+     *
      * @expectedException InvalidArgumentException
+     *
      * @expectedExceptionMessage Module Phug\Test\Util\FirstTestModule is already registered.
      */
     public function testDoubleRegistration()
@@ -131,7 +135,9 @@ class ModuleContainerTest extends TestCase
     /**
      * @covers ::getModuleBaseClassName
      * @covers ::addModule
+     *
      * @expectedException InvalidArgumentException
+     *
      * @expectedExceptionMessage This occurrence of Phug\Test\Util\FirstTestModule is already registered.
      */
     public function testInstanceDoubleRegistration()
@@ -148,7 +154,9 @@ class ModuleContainerTest extends TestCase
     /**
      * @covers ::getModuleBaseClassName
      * @covers ::addModule
+     *
      * @expectedException InvalidArgumentException
+     *
      * @expectedExceptionMessage This occurrence of Phug\Test\Util\FirstTestModule is already registered in another module container.
      */
     public function testInstanceDivergentRegistrations()
@@ -164,7 +172,9 @@ class ModuleContainerTest extends TestCase
     /**
      * @covers ::getModuleBaseClassName
      * @covers ::removeModule
+     *
      * @expectedException InvalidArgumentException
+     *
      * @expectedExceptionMessage The container doesn't contain a Phug\Test\Util\FirstTestModule module
      */
     public function testRemovalOfNonExistentModule()
@@ -180,7 +190,9 @@ class ModuleContainerTest extends TestCase
     /**
      * @covers ::getModuleBaseClassName
      * @covers ::removeModule
+     *
      * @expectedException InvalidArgumentException
+     *
      * @expectedExceptionMessage This occurrence of Phug\Test\Util\FirstTestModule is not registered.
      */
     public function testRemovalOfNonExistentModuleInstance()
@@ -196,7 +208,9 @@ class ModuleContainerTest extends TestCase
 
     /**
      * @covers ::addModule
+     *
      * @expectedException \RuntimeException
+     *
      * @expectedExceptionMessage Current module container uses the ModuleContainerTrait, but doesn't implement Phug\Util\ModuleContainerInterface, please implement it.
      */
     public function testNonInterfacedContainer()

--- a/tests/Phug/Util/OrderedValueTest.php
+++ b/tests/Phug/Util/OrderedValueTest.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Phug\Test\Util;
+
+use PHPUnit\Framework\TestCase;
+use Phug\Util\OrderedValue;
+
+/**
+ * @coversDefaultClass \Phug\Util\OrderedValue
+ */
+class OrderedValueTest extends TestCase
+{
+    /**
+     * @covers ::__construct
+     */
+    public function testObject()
+    {
+        $value = new OrderedValue(42, 3);
+
+        self::assertSame(42, $value->getValue());
+        self::assertSame(3, $value->getOrder());
+
+        $value->setOrder(null);
+        $value->setValue('Hello');
+
+        self::assertSame('Hello', $value->getValue());
+        self::assertSame(null, $value->getOrder());
+    }
+}

--- a/tests/Phug/Util/UnorderedArgumentsTest.php
+++ b/tests/Phug/Util/UnorderedArgumentsTest.php
@@ -47,7 +47,9 @@ class UnorderedArgumentsTest extends TestCase
 
     /**
      * @covers                   ::required
+     *
      * @expectedException        \InvalidArgumentException
+     *
      * @expectedExceptionMessage Arguments miss one of the boolean type
      */
     public function testRequiredException()
@@ -72,7 +74,9 @@ class UnorderedArgumentsTest extends TestCase
     /**
      * @covers                   ::noMoreArguments
      * @covers                   ::noMoreDefinedArguments
+     *
      * @expectedException        \InvalidArgumentException
+     *
      * @expectedExceptionMessage You pass 2 unexpected arguments
      */
     public function testNoMoreArgumentsException()
@@ -87,7 +91,9 @@ class UnorderedArgumentsTest extends TestCase
     /**
      * @covers                   ::noMoreArguments
      * @covers                   ::noMoreDefinedArguments
+     *
      * @expectedException        \InvalidArgumentException
+     *
      * @expectedExceptionMessage You pass 2 unexpected arguments
      */
     public function testNoMoreUndefinedArgumentsException()
@@ -103,7 +109,9 @@ class UnorderedArgumentsTest extends TestCase
     /**
      * @covers                   ::noMoreArguments
      * @covers                   ::noMoreDefinedArguments
+     *
      * @expectedException        \InvalidArgumentException
+     *
      * @expectedExceptionMessage You pass 1 unexpected not null arguments
      */
     public function testNoMoreDefinedArgumentsException()

--- a/tests/Phug/Utils/AssertRender.php
+++ b/tests/Phug/Utils/AssertRender.php
@@ -47,7 +47,7 @@ trait AssertRender
             sort($attributes);
 
             return ' '.implode(' ', $attributes);
-        }, is_string($str) ? $str : implode('', $str));
+        }, str_replace("\r", '', is_string($str) ? $str : implode('', $str)));
     }
 
     protected function assertSameLines($expected, $actual)

--- a/tests/Phug/Utils/AssertRender.php
+++ b/tests/Phug/Utils/AssertRender.php
@@ -18,7 +18,7 @@ trait AssertRender
         }
 
         $this->compiler = new Compiler([
-            'paths'    => [__DIR__.'/../templates'],
+            'paths'    => [__DIR__.'/../../templates'],
             'patterns' => [
                 'expression_in_text' => '%s',
                 'expression_in_bool' => '%s',
@@ -32,10 +32,10 @@ trait AssertRender
             $attributes = [];
             $input = $matches[0];
             while (mb_strlen($input) && preg_match(
-                    '/^\s+([a-z0-9:_-]+)="((?:\\\\[\\S\\s]|[^"\\\\])*)"/',
-                    $input,
-                    $match
-                )) {
+                '/^\s+([a-z0-9:_-]+)="((?:\\\\[\\S\\s]|[^"\\\\])*)"/',
+                $input,
+                $match
+            )) {
                 if ($match[1] === 'class') {
                     $classes = explode(' ', $match[2]);
                     sort($classes);

--- a/tests/Phug/Utils/AssertRender.php
+++ b/tests/Phug/Utils/AssertRender.php
@@ -1,0 +1,114 @@
+<?php
+
+namespace Phug\Test\Utils;
+
+use Phug\Compiler;
+
+trait AssertRender
+{
+    /**
+     * @var Compiler
+     */
+    protected $compiler;
+
+    protected function prepareTest()
+    {
+        if (isset($this->compiler)) {
+            return;
+        }
+
+        $this->compiler = new Compiler([
+            'paths'    => [__DIR__.'/../templates'],
+            'patterns' => [
+                'expression_in_text' => '%s',
+                'expression_in_bool' => '%s',
+            ],
+        ]);
+    }
+
+    protected function implodeLines($str)
+    {
+        return preg_replace_callback('/(\s+[a-z0-9:_-]+="(?:\\\\[\\S\\s]|[^"\\\\])*")+/', function ($matches) {
+            $attributes = [];
+            $input = $matches[0];
+            while (mb_strlen($input) && preg_match(
+                    '/^\s+([a-z0-9:_-]+)="((?:\\\\[\\S\\s]|[^"\\\\])*)"/',
+                    $input,
+                    $match
+                )) {
+                if ($match[1] === 'class') {
+                    $classes = explode(' ', $match[2]);
+                    sort($classes);
+                    $match[2] = implode(' ', $classes);
+                }
+                $attributes[] = trim($match[1]).'="'.$match[2].'"';
+                $input = mb_substr($input, mb_strlen($match[0]));
+            }
+            sort($attributes);
+
+            return ' '.implode(' ', $attributes);
+        }, is_string($str) ? $str : implode('', $str));
+    }
+
+    protected function assertSameLines($expected, $actual)
+    {
+        self::assertSame($this->implodeLines($expected), $this->implodeLines($actual));
+    }
+
+    protected function assertCompile($expected, $actual, array $options = [])
+    {
+        $compiler = clone $this->compiler;
+        $compiler->setOptionsRecursive($options);
+
+        $this->assertSameLines($expected, $compiler->compile($this->implodeLines($actual)));
+    }
+
+    protected function assertCompileFile($expected, $actual)
+    {
+        $this->assertSameLines($expected, $this->compiler->compileFile($actual));
+    }
+
+    protected function getRenderedHtml($php, array $variables = [])
+    {
+        if (getenv('LOG_COMPILE')) {
+            file_put_contents('temp.php', $php);
+        }
+        extract($variables);
+        ob_start();
+        eval('?>'.$php);
+        $actual = ob_get_contents();
+        ob_end_clean();
+
+        return $actual;
+    }
+
+    protected function render($actual, array $options = [], array $variables = [])
+    {
+        $compiler = $this->compiler;
+        $compiler->setOptionsRecursive($options);
+        $php = $compiler->compile($this->implodeLines($actual));
+
+        return $this->getRenderedHtml($php, $variables);
+    }
+
+    protected function assertRender($expected, $actual, array $options = [], array $variables = [])
+    {
+        $actual = $this->render($actual, $options, $variables);
+
+        $this->assertSameLines($expected, $actual);
+    }
+
+    protected function assertRenderFile($expected, $actual, array $options = [], array $variables = [])
+    {
+        $compiler = $this->compiler;
+        $compiler->setOptionsRecursive($options);
+        $php = $compiler->compileFile($actual);
+        $actual = preg_replace(
+            '/\s(class|id)=""/',
+            '',
+            $this->getRenderedHtml($php, $variables)
+        );
+
+        $this->assertSameLines($expected, $actual);
+    }
+}


### PR DESCRIPTION
### attribute_precedence `"assignment"` (default value), `"attribute"`, `"left"`, `"right"`, `callable` 

Allow to customize precedence between attributes and `&attribute` assignment.

```php
Phug::display('
| Last assignment
- $data = ["href" => "/c"]
a(href="/a")&attributes(["href" => "/b"])&attributes($data)(href="/d")
', [], [
    'attribute_precedence' => 'assignment',
]);

Phug::display('
| Last attribute
- $data = ["href" => "/c"]
a(href="/a")&attributes(["href" => "/b"])&attributes($data)(href="/d")
', [], [
    'attribute_precedence' => 'attribute',
]);

Phug::display('
| First token (either it’s attribute or assignment)
- $data = ["href" => "/c"]
a(href="/a")&attributes(["href" => "/b"])&attributes($data)(href="/d")
', [], [
    'attribute_precedence' => 'left',
]);

Phug::display('
| Last token (either it’s attribute or assignment)
- $data = ["href" => "/c"]
a(href="/a")&attributes(["href" => "/b"])&attributes($data)(href="/d")
', [], [
    'attribute_precedence' => 'right',
]);

Phug::display('
| First assignment
- $data = ["href" => "/c"]
a(href="/a")&attributes(["href" => "/b"])&attributes($data)(href="/d")
', [], [
    'attribute_precedence' => static function (array $assignments, array $attributes) {
        // Sort in reverse-order (right-most tokens to left-most tokens)
        usort($assignments, static function (\Phug\Util\OrderedValue $a, \Phug\Util\OrderedValue $b) {
            return $b->getOrder() - $a->getOrder();
        });
        usort($attributes, static function (\Phug\Util\OrderedValue $a, \Phug\Util\OrderedValue $b) {
            return $b->getOrder() - $a->getOrder();
        });

        // Return order in which values will merge
        // So from lowest to highest precedence
        return array_merge($attributes, $assignments);
    },
]);

Phug::display('
| First attribute
- $data = ["href" => "/c"]
a(href="/a")&attributes(["href" => "/b"])&attributes($data)(href="/d")
', [], [
    'attribute_precedence' => static function (array $assignments, array $attributes) {
        // Sort in reverse-order (right-most tokens to left-most tokens)
        usort($assignments, static function (\Phug\Util\OrderedValue $a, \Phug\Util\OrderedValue $b) {
            return $b->getOrder() - $a->getOrder();
        });
        usort($attributes, static function (\Phug\Util\OrderedValue $a, \Phug\Util\OrderedValue $b) {
            return $b->getOrder() - $a->getOrder();
        });

        // Return order in which values will merge
        // So from lowest to highest precedence
        return array_merge($assignments, $attributes);
    },
]);
```

Output:
```html
Last assignment
<a href="/c"></a>

Last attribute
<a href="/d"></a>

First token (either it’s attribute or assignment)
<a href="/a"></a>

Last token (either it’s attribute or assignment)
<a href="/d"></a>

First assignment
<a href="/b"></a>

First attribute
<a href="/a"></a>
```

Fix #88