### PR TITLE
minimal corrections to avoid implicit nullable deprecation warning

### DIFF
--- a/src/Phug/Ast/Ast/Node.php
+++ b/src/Phug/Ast/Ast/Node.php
@@ -31,7 +31,7 @@ class Node implements NodeInterface
      * @param NodeInterface $parent
      * @param array         $children
      */
-    public function __construct(NodeInterface $parent = null, array $children = null)
+    public function __construct(?NodeInterface $parent = null, ?array $children = null)
     {
         $this->parent = null;
         $this->children = [];
@@ -77,7 +77,7 @@ class Node implements NodeInterface
     /**
      * {@inheritdoc}
      */
-    public function setParent(NodeInterface $parent = null)
+    public function setParent(?NodeInterface $parent = null)
     {
         if ($this->parent === $parent) {
             return $this;

--- a/src/Phug/Compiler/Compiler.php
+++ b/src/Phug/Compiler/Compiler.php
@@ -499,7 +499,7 @@ class Compiler implements ModuleContainerInterface, CompilerInterface, WithUpper
      *
      * @return ElementInterface
      */
-    public function compileNode(NodeInterface $node, ElementInterface $parent = null)
+    public function compileNode(NodeInterface $node, ?ElementInterface $parent = null)
     {
         $nodeEvent = new NodeEvent($node);
         $this->trigger($nodeEvent);
@@ -537,7 +537,7 @@ class Compiler implements ModuleContainerInterface, CompilerInterface, WithUpper
      * @param BlockElement $block
      * @param array        $children
      */
-    public function replaceBlock(BlockElement $block, array $children = null)
+    public function replaceBlock(BlockElement $block, ?array $children = null)
     {
         if ($parent = $block->getParent()) {
             foreach (array_reverse($children ?: $block->getChildren()) as $child) {

--- a/src/Phug/Compiler/Compiler/AbstractNodeCompiler.php
+++ b/src/Phug/Compiler/Compiler/AbstractNodeCompiler.php
@@ -41,7 +41,7 @@ abstract class AbstractNodeCompiler implements NodeCompilerInterface
      *
      * @return ElementInterface[]
      */
-    public function getCompiledNodeList($nodeList, ElementInterface $element = null)
+    public function getCompiledNodeList($nodeList, ?ElementInterface $element = null)
     {
         return array_values(array_filter(array_map(
             function (NodeInterface $childNode) use ($element) {
@@ -59,7 +59,7 @@ abstract class AbstractNodeCompiler implements NodeCompilerInterface
      *
      * @return ElementInterface[]
      */
-    public function getCompiledChildren(NodeInterface $node, ElementInterface $element = null)
+    public function getCompiledChildren(NodeInterface $node, ?ElementInterface $element = null)
     {
         return $this->getCompiledNodeList($node->getChildren(), $element);
     }
@@ -71,7 +71,7 @@ abstract class AbstractNodeCompiler implements NodeCompilerInterface
      * @param NodeInterface         $node
      * @param ElementInterface|null $element
      */
-    public function compileNodeChildren(NodeInterface $node, ElementInterface $element = null)
+    public function compileNodeChildren(NodeInterface $node, ?ElementInterface $element = null)
     {
         $children = array_filter($node->getChildren());
         array_walk($children, function (NodeInterface $childNode) use ($element) {
@@ -109,7 +109,7 @@ abstract class AbstractNodeCompiler implements NodeCompilerInterface
         }, $children));
     }
 
-    private function compileParserNode(NodeInterface $node, ElementInterface $element = null)
+    private function compileParserNode(NodeInterface $node, ?ElementInterface $element = null)
     {
         return $node instanceof ParserNodeInterface
             ? $this->getCompiler()->compileNode($node, $element)

--- a/src/Phug/Compiler/Compiler/Element/BlockElement.php
+++ b/src/Phug/Compiler/Compiler/Element/BlockElement.php
@@ -22,9 +22,9 @@ class BlockElement extends AbstractElement
     public function __construct(
         CompilerInterface $compiler,
         $name = '',
-        ParserNode $originNode = null,
-        NodeInterface $parent = null,
-        array $children = null
+        ?ParserNode $originNode = null,
+        ?NodeInterface $parent = null,
+        ?array $children = null
     ) {
         $blocks = &$compiler->getBlocksByName($name);
         $blocks[] = $this;

--- a/src/Phug/Compiler/Compiler/NodeCompiler/AssignmentListNodeCompiler.php
+++ b/src/Phug/Compiler/Compiler/NodeCompiler/AssignmentListNodeCompiler.php
@@ -9,7 +9,7 @@ use Phug\Parser\NodeInterface;
 
 class AssignmentListNodeCompiler extends AbstractNodeCompiler
 {
-    public function compileNode(NodeInterface $node, ElementInterface $parent = null)
+    public function compileNode(NodeInterface $node, ?ElementInterface $parent = null)
     {
         $this->getCompiler()->assert(
             $node instanceof AssignmentListNode,

--- a/src/Phug/Compiler/Compiler/NodeCompiler/AssignmentNodeCompiler.php
+++ b/src/Phug/Compiler/Compiler/NodeCompiler/AssignmentNodeCompiler.php
@@ -13,7 +13,7 @@ use SplObjectStorage;
 
 class AssignmentNodeCompiler extends AbstractNodeCompiler
 {
-    public function compileNode(NodeInterface $node, ElementInterface $parent = null)
+    public function compileNode(NodeInterface $node, ?ElementInterface $parent = null)
     {
         $this->getCompiler()->assert(
             $node instanceof AssignmentNode,

--- a/src/Phug/Compiler/Compiler/NodeCompiler/AttributeListNodeCompiler.php
+++ b/src/Phug/Compiler/Compiler/NodeCompiler/AttributeListNodeCompiler.php
@@ -9,7 +9,7 @@ use Phug\Parser\NodeInterface;
 
 class AttributeListNodeCompiler extends AbstractNodeCompiler
 {
-    public function compileNode(NodeInterface $node, ElementInterface $parent = null)
+    public function compileNode(NodeInterface $node, ?ElementInterface $parent = null)
     {
         $this->getCompiler()->assert(
             $node instanceof AttributeListNode,

--- a/src/Phug/Compiler/Compiler/NodeCompiler/AttributeNodeCompiler.php
+++ b/src/Phug/Compiler/Compiler/NodeCompiler/AttributeNodeCompiler.php
@@ -57,7 +57,7 @@ class AttributeNodeCompiler extends AbstractNodeCompiler
         return $value;
     }
 
-    public function compileNode(NodeInterface $node, ElementInterface $parent = null)
+    public function compileNode(NodeInterface $node, ?ElementInterface $parent = null)
     {
         $this->getCompiler()->assert(
             $node instanceof AttributeNode,

--- a/src/Phug/Compiler/Compiler/NodeCompiler/BlockNodeCompiler.php
+++ b/src/Phug/Compiler/Compiler/NodeCompiler/BlockNodeCompiler.php
@@ -12,7 +12,7 @@ use Phug\Parser\NodeInterface;
 
 class BlockNodeCompiler extends AbstractNodeCompiler
 {
-    protected function compileAnonymousBlock(BlockNode $node, ElementInterface $parent = null)
+    protected function compileAnonymousBlock(BlockNode $node, ?ElementInterface $parent = null)
     {
         $mixin = $node;
         while ($mixin->hasParent() && !($mixin instanceof MixinNode)) {
@@ -38,7 +38,7 @@ class BlockNodeCompiler extends AbstractNodeCompiler
         return false;
     }
 
-    protected function compileNamedBlock($name, BlockNode $node, ElementInterface $parent = null)
+    protected function compileNamedBlock($name, BlockNode $node, ?ElementInterface $parent = null)
     {
         $compiler = $this->getCompiler();
         $layout = $compiler->getLayout();
@@ -63,7 +63,7 @@ class BlockNodeCompiler extends AbstractNodeCompiler
         );
     }
 
-    public function compileNode(NodeInterface $node, ElementInterface $parent = null)
+    public function compileNode(NodeInterface $node, ?ElementInterface $parent = null)
     {
         $this->getCompiler()->assert(
             $node instanceof BlockNode,

--- a/src/Phug/Compiler/Compiler/NodeCompiler/CaseNodeCompiler.php
+++ b/src/Phug/Compiler/Compiler/NodeCompiler/CaseNodeCompiler.php
@@ -8,7 +8,7 @@ use Phug\Parser\NodeInterface;
 
 class CaseNodeCompiler extends AbstractStatementNodeCompiler
 {
-    public function compileNode(NodeInterface $node, ElementInterface $parent = null)
+    public function compileNode(NodeInterface $node, ?ElementInterface $parent = null)
     {
         $this->getCompiler()->assert(
             $node instanceof CaseNode,

--- a/src/Phug/Compiler/Compiler/NodeCompiler/CodeNodeCompiler.php
+++ b/src/Phug/Compiler/Compiler/NodeCompiler/CodeNodeCompiler.php
@@ -12,7 +12,7 @@ use Phug\Parser\NodeInterface;
 
 class CodeNodeCompiler extends AbstractNodeCompiler
 {
-    public function compileNode(NodeInterface $node, ElementInterface $parent = null)
+    public function compileNode(NodeInterface $node, ?ElementInterface $parent = null)
     {
         $this->getCompiler()->assert(
             $node instanceof CodeNode,
@@ -42,7 +42,7 @@ class CodeNodeCompiler extends AbstractNodeCompiler
         return $code;
     }
 
-    private function getCodeElement(CodeNode $node, array $texts, array $children, ElementInterface $parent = null)
+    private function getCodeElement(CodeNode $node, array $texts, array $children, ?ElementInterface $parent = null)
     {
         if (count($texts) === count($children)) {
             return new CodeElement($this->getTextChildren($node), $node);

--- a/src/Phug/Compiler/Compiler/NodeCompiler/CommentNodeCompiler.php
+++ b/src/Phug/Compiler/Compiler/NodeCompiler/CommentNodeCompiler.php
@@ -10,7 +10,7 @@ use Phug\Parser\NodeInterface;
 
 class CommentNodeCompiler extends AbstractNodeCompiler
 {
-    public function compileNode(NodeInterface $node, ElementInterface $parent = null)
+    public function compileNode(NodeInterface $node, ?ElementInterface $parent = null)
     {
         $this->getCompiler()->assert(
             $node instanceof CommentNode,

--- a/src/Phug/Compiler/Compiler/NodeCompiler/ConditionalNodeCompiler.php
+++ b/src/Phug/Compiler/Compiler/NodeCompiler/ConditionalNodeCompiler.php
@@ -9,7 +9,7 @@ use Phug\Util\TransformableInterface;
 
 class ConditionalNodeCompiler extends AbstractStatementNodeCompiler
 {
-    public function compileNode(NodeInterface $node, ElementInterface $parent = null)
+    public function compileNode(NodeInterface $node, ?ElementInterface $parent = null)
     {
         $compiler = $this->getCompiler();
 

--- a/src/Phug/Compiler/Compiler/NodeCompiler/DoNodeCompiler.php
+++ b/src/Phug/Compiler/Compiler/NodeCompiler/DoNodeCompiler.php
@@ -8,7 +8,7 @@ use Phug\Parser\NodeInterface;
 
 class DoNodeCompiler extends AbstractStatementNodeCompiler
 {
-    public function compileNode(NodeInterface $node, ElementInterface $parent = null)
+    public function compileNode(NodeInterface $node, ?ElementInterface $parent = null)
     {
         $this->getCompiler()->assert(
             $node instanceof DoNode,

--- a/src/Phug/Compiler/Compiler/NodeCompiler/DoctypeNodeCompiler.php
+++ b/src/Phug/Compiler/Compiler/NodeCompiler/DoctypeNodeCompiler.php
@@ -10,7 +10,7 @@ use Phug\Parser\NodeInterface;
 
 class DoctypeNodeCompiler extends AbstractNodeCompiler
 {
-    public function compileNode(NodeInterface $node, ElementInterface $parent = null)
+    public function compileNode(NodeInterface $node, ?ElementInterface $parent = null)
     {
         $compiler = $this->getCompiler();
         $compiler->assert(

--- a/src/Phug/Compiler/Compiler/NodeCompiler/DocumentNodeCompiler.php
+++ b/src/Phug/Compiler/Compiler/NodeCompiler/DocumentNodeCompiler.php
@@ -10,7 +10,7 @@ use Phug\Parser\NodeInterface;
 
 class DocumentNodeCompiler extends AbstractNodeCompiler
 {
-    public function compileNode(NodeInterface $node, ElementInterface $parent = null)
+    public function compileNode(NodeInterface $node, ?ElementInterface $parent = null)
     {
         $this->getCompiler()->assert(
             $node instanceof DocumentNode,

--- a/src/Phug/Compiler/Compiler/NodeCompiler/EachNodeCompiler.php
+++ b/src/Phug/Compiler/Compiler/NodeCompiler/EachNodeCompiler.php
@@ -76,7 +76,7 @@ class EachNodeCompiler extends AbstractStatementNodeCompiler
         return $loop;
     }
 
-    public function compileNode(NodeInterface $node, ElementInterface $parent = null)
+    public function compileNode(NodeInterface $node, ?ElementInterface $parent = null)
     {
         $this->getCompiler()->assert(
             $node instanceof EachNode,

--- a/src/Phug/Compiler/Compiler/NodeCompiler/ElementNodeCompiler.php
+++ b/src/Phug/Compiler/Compiler/NodeCompiler/ElementNodeCompiler.php
@@ -14,7 +14,7 @@ use SplObjectStorage;
 
 class ElementNodeCompiler extends AbstractNodeCompiler
 {
-    public function compileNode(NodeInterface $node, ElementInterface $parent = null)
+    public function compileNode(NodeInterface $node, ?ElementInterface $parent = null)
     {
         $compiler = $this->getCompiler();
         $compiler->assert(

--- a/src/Phug/Compiler/Compiler/NodeCompiler/ExpressionNodeCompiler.php
+++ b/src/Phug/Compiler/Compiler/NodeCompiler/ExpressionNodeCompiler.php
@@ -10,7 +10,7 @@ use Phug\Parser\NodeInterface;
 
 class ExpressionNodeCompiler extends AbstractNodeCompiler
 {
-    public function compileNode(NodeInterface $node, ElementInterface $parent = null)
+    public function compileNode(NodeInterface $node, ?ElementInterface $parent = null)
     {
         $this->getCompiler()->assert(
             $node instanceof ExpressionNode,

--- a/src/Phug/Compiler/Compiler/NodeCompiler/FilterNodeCompiler.php
+++ b/src/Phug/Compiler/Compiler/NodeCompiler/FilterNodeCompiler.php
@@ -40,7 +40,7 @@ class FilterNodeCompiler extends AbstractNodeCompiler
         }, $children));
     }
 
-    public function compileNode(NodeInterface $node, ElementInterface $parent = null)
+    public function compileNode(NodeInterface $node, ?ElementInterface $parent = null)
     {
         $compiler = $this->getCompiler();
         $compiler->assert(

--- a/src/Phug/Compiler/Compiler/NodeCompiler/ForNodeCompiler.php
+++ b/src/Phug/Compiler/Compiler/NodeCompiler/ForNodeCompiler.php
@@ -8,7 +8,7 @@ use Phug\Parser\NodeInterface;
 
 class ForNodeCompiler extends EachNodeCompiler
 {
-    public function compileNode(NodeInterface $node, ElementInterface $parent = null)
+    public function compileNode(NodeInterface $node, ?ElementInterface $parent = null)
     {
         $this->getCompiler()->assert(
             $node instanceof ForNode,

--- a/src/Phug/Compiler/Compiler/NodeCompiler/ImportNodeCompiler.php
+++ b/src/Phug/Compiler/Compiler/NodeCompiler/ImportNodeCompiler.php
@@ -51,7 +51,7 @@ class ImportNodeCompiler extends AbstractNodeCompiler
      *
      * @return null|ElementInterface
      */
-    public function compileNode(NodeInterface $node, ElementInterface $parent = null)
+    public function compileNode(NodeInterface $node, ?ElementInterface $parent = null)
     {
         $compiler = $this->getCompiler();
         $compiler->assert(

--- a/src/Phug/Compiler/Compiler/NodeCompiler/KeywordNodeCompiler.php
+++ b/src/Phug/Compiler/Compiler/NodeCompiler/KeywordNodeCompiler.php
@@ -10,7 +10,7 @@ use Phug\Parser\NodeInterface;
 
 class KeywordNodeCompiler extends AbstractNodeCompiler
 {
-    public function compileNode(NodeInterface $node, ElementInterface $parent = null)
+    public function compileNode(NodeInterface $node, ?ElementInterface $parent = null)
     {
         $this->getCompiler()->assert(
             $node instanceof KeywordNode,

--- a/src/Phug/Compiler/Compiler/NodeCompiler/MixinCallNodeCompiler.php
+++ b/src/Phug/Compiler/Compiler/NodeCompiler/MixinCallNodeCompiler.php
@@ -14,7 +14,7 @@ use Phug\Parser\NodeInterface as ParserNodeInterface;
 
 class MixinCallNodeCompiler extends AbstractNodeCompiler
 {
-    public function compileNode(ParserNodeInterface $node, ElementInterface $parent = null)
+    public function compileNode(ParserNodeInterface $node, ?ElementInterface $parent = null)
     {
         $compiler = $this->getCompiler();
         $compiler->assert(

--- a/src/Phug/Compiler/Compiler/NodeCompiler/MixinNodeCompiler.php
+++ b/src/Phug/Compiler/Compiler/NodeCompiler/MixinNodeCompiler.php
@@ -13,7 +13,7 @@ use Phug\Parser\NodeInterface;
 
 class MixinNodeCompiler extends AbstractNodeCompiler
 {
-    public function compileNode(NodeInterface $node, ElementInterface $parent = null)
+    public function compileNode(NodeInterface $node, ?ElementInterface $parent = null)
     {
         $compiler = $this->getCompiler();
         $compiler->assert(

--- a/src/Phug/Compiler/Compiler/NodeCompiler/TextNodeCompiler.php
+++ b/src/Phug/Compiler/Compiler/NodeCompiler/TextNodeCompiler.php
@@ -10,7 +10,7 @@ use Phug\Parser\NodeInterface;
 
 class TextNodeCompiler extends AbstractNodeCompiler
 {
-    public function compileNode(NodeInterface $node, ElementInterface $parent = null)
+    public function compileNode(NodeInterface $node, ?ElementInterface $parent = null)
     {
         $this->getCompiler()->assert(
             $node instanceof TextNode,

--- a/src/Phug/Compiler/Compiler/NodeCompiler/VariableNodeCompiler.php
+++ b/src/Phug/Compiler/Compiler/NodeCompiler/VariableNodeCompiler.php
@@ -10,7 +10,7 @@ use Phug\Parser\NodeInterface;
 
 class VariableNodeCompiler extends AbstractNodeCompiler
 {
-    public function compileNode(NodeInterface $node, ElementInterface $parent = null)
+    public function compileNode(NodeInterface $node, ?ElementInterface $parent = null)
     {
         $compiler = $this->getCompiler();
         $compiler->assert(

--- a/src/Phug/Compiler/Compiler/NodeCompiler/WhenNodeCompiler.php
+++ b/src/Phug/Compiler/Compiler/NodeCompiler/WhenNodeCompiler.php
@@ -10,7 +10,7 @@ use Phug\Parser\NodeInterface;
 
 class WhenNodeCompiler extends AbstractNodeCompiler
 {
-    public function compileNode(NodeInterface $node, ElementInterface $parent = null)
+    public function compileNode(NodeInterface $node, ?ElementInterface $parent = null)
     {
         $this->getCompiler()->assert(
             $node instanceof WhenNode,

--- a/src/Phug/Compiler/Compiler/NodeCompiler/WhileNodeCompiler.php
+++ b/src/Phug/Compiler/Compiler/NodeCompiler/WhileNodeCompiler.php
@@ -9,7 +9,7 @@ use Phug\Parser\NodeInterface;
 
 class WhileNodeCompiler extends AbstractStatementNodeCompiler
 {
-    public function compileNode(NodeInterface $node, ElementInterface $parent = null)
+    public function compileNode(NodeInterface $node, ?ElementInterface $parent = null)
     {
         $compiler = $this->getCompiler();
         $compiler->assert(

--- a/src/Phug/Compiler/Compiler/NodeCompiler/YieldNodeCompiler.php
+++ b/src/Phug/Compiler/Compiler/NodeCompiler/YieldNodeCompiler.php
@@ -10,7 +10,7 @@ use Phug\Parser\NodeInterface;
 
 class YieldNodeCompiler extends AbstractNodeCompiler
 {
-    public function compileNode(NodeInterface $node, ElementInterface $parent = null)
+    public function compileNode(NodeInterface $node, ?ElementInterface $parent = null)
     {
         $compiler = $this->getCompiler();
         $compiler->assert(

--- a/src/Phug/Compiler/Compiler/NodeCompilerInterface.php
+++ b/src/Phug/Compiler/Compiler/NodeCompilerInterface.php
@@ -16,7 +16,7 @@ interface NodeCompilerInterface
      *
      * @return array
      */
-    public function getCompiledNodeList($nodeList, ElementInterface $parent = null);
+    public function getCompiledNodeList($nodeList, ?ElementInterface $parent = null);
 
     /**
      * @param NodeInterface    $node
@@ -24,7 +24,7 @@ interface NodeCompilerInterface
      *
      * @return array
      */
-    public function getCompiledChildren(NodeInterface $node, ElementInterface $parent = null);
+    public function getCompiledChildren(NodeInterface $node, ?ElementInterface $parent = null);
 
     /**
      * @param NodeInterface         $node
@@ -32,7 +32,7 @@ interface NodeCompilerInterface
      *
      * @return mixed
      */
-    public function compileNodeChildren(NodeInterface $node, ElementInterface $element = null);
+    public function compileNodeChildren(NodeInterface $node, ?ElementInterface $element = null);
 
     /**
      * @param ParserNodeInterface $node
@@ -40,7 +40,7 @@ interface NodeCompilerInterface
      *
      * @return null|BlockElement|ElementInterface
      */
-    public function compileNode(ParserNodeInterface $node, ElementInterface $parent = null);
+    public function compileNode(ParserNodeInterface $node, ?ElementInterface $parent = null);
 
     /**
      * @return CompilerInterface

--- a/src/Phug/Compiler/CompilerInterface.php
+++ b/src/Phug/Compiler/CompilerInterface.php
@@ -92,7 +92,7 @@ interface CompilerInterface extends ModuleContainerInterface
      * @param BlockElement $block
      * @param array        $children
      */
-    public function replaceBlock(BlockElement $block, array $children = null);
+    public function replaceBlock(BlockElement $block, ?array $children = null);
 
     /**
      * @throws CompilerException
@@ -133,7 +133,7 @@ interface CompilerInterface extends ModuleContainerInterface
      *
      * @return null|ElementInterface
      */
-    public function compileNode(NodeInterface $node, ElementInterface $parent = null);
+    public function compileNode(NodeInterface $node, ?ElementInterface $parent = null);
 
     /**
      * @param string $input

--- a/src/Phug/Formatter/Formatter/AbstractElement.php
+++ b/src/Phug/Formatter/Formatter/AbstractElement.php
@@ -20,7 +20,7 @@ abstract class AbstractElement extends Node implements ElementInterface
      * @param NodeInterface|null $parent
      * @param array|null         $children
      */
-    public function __construct(ParserNode $originNode = null, NodeInterface $parent = null, array $children = null)
+    public function __construct(?ParserNode $originNode = null, ?NodeInterface $parent = null, ?array $children = null)
     {
         $this->originNode = $originNode;
 

--- a/src/Phug/Formatter/Formatter/AbstractFormat.php
+++ b/src/Phug/Formatter/Formatter/AbstractFormat.php
@@ -77,7 +77,7 @@ abstract class AbstractFormat implements FormatInterface, OptionInterface
      */
     private $debugCommentPattern = null;
 
-    public function __construct(Formatter $formatter = null)
+    public function __construct(?Formatter $formatter = null)
     {
         $patterns = [
             'class_attribute'        => static::CLASS_ATTRIBUTE,
@@ -1003,7 +1003,7 @@ abstract class AbstractFormat implements FormatInterface, OptionInterface
         return $this->formatElementChildren($document, 0);
     }
 
-    protected function throwException($message, ElementInterface $element = null)
+    protected function throwException($message, ?ElementInterface $element = null)
     {
         $location = ($node = $element->getOriginNode()) && ($loc = $node->getSourceLocation())
             ? clone $loc

--- a/src/Phug/Formatter/Formatter/Element/AbstractValueElement.php
+++ b/src/Phug/Formatter/Formatter/Element/AbstractValueElement.php
@@ -21,9 +21,9 @@ abstract class AbstractValueElement extends AbstractElement
      */
     public function __construct(
         $value = null,
-        ParserNode $originNode = null,
-        NodeInterface $parent = null,
-        array $children = null
+        ?ParserNode $originNode = null,
+        ?NodeInterface $parent = null,
+        ?array $children = null
     ) {
         parent::__construct($originNode, $parent, $children);
 

--- a/src/Phug/Formatter/Formatter/Element/AnonymousBlockElement.php
+++ b/src/Phug/Formatter/Formatter/Element/AnonymousBlockElement.php
@@ -7,7 +7,7 @@ use Phug\Parser\NodeInterface as ParserNode;
 
 class AnonymousBlockElement extends ExpressionElement
 {
-    public function __construct(ParserNode $originNode = null, NodeInterface $parent = null, array $children = null)
+    public function __construct(?ParserNode $originNode = null, ?NodeInterface $parent = null, ?array $children = null)
     {
         parent::__construct('$__pug_children(get_defined_vars())', $originNode, $parent, $children);
         $this->uncheck();

--- a/src/Phug/Formatter/Formatter/Element/AssignmentElement.php
+++ b/src/Phug/Formatter/Formatter/Element/AssignmentElement.php
@@ -31,11 +31,11 @@ class AssignmentElement extends AbstractElement implements AttributesInterface, 
      */
     public function __construct(
         $name,
-        SplObjectStorage $attributes = null,
-        AssignmentContainerInterface $container = null,
-        ParserNode $originNode = null,
-        NodeInterface $parent = null,
-        array $children = null
+        ?SplObjectStorage $attributes = null,
+        ?AssignmentContainerInterface $container = null,
+        ?ParserNode $originNode = null,
+        ?NodeInterface $parent = null,
+        ?array $children = null
     ) {
         parent::__construct($originNode, $parent, $children);
 

--- a/src/Phug/Formatter/Formatter/Element/AttributeElement.php
+++ b/src/Phug/Formatter/Formatter/Element/AttributeElement.php
@@ -27,9 +27,9 @@ class AttributeElement extends AbstractValueElement implements OrderableInterfac
     public function __construct(
         $name,
         $value,
-        ParserNode $originNode = null,
-        NodeInterface $parent = null,
-        array $children = null
+        ?ParserNode $originNode = null,
+        ?NodeInterface $parent = null,
+        ?array $children = null
     ) {
         parent::__construct($originNode, $parent, $children);
 

--- a/src/Phug/Formatter/Formatter/Element/CodeElement.php
+++ b/src/Phug/Formatter/Formatter/Element/CodeElement.php
@@ -34,9 +34,9 @@ class CodeElement extends AbstractValueElement implements TransformableInterface
      */
     public function __construct(
         $value = null,
-        ParserNode $originNode = null,
-        NodeInterface $parent = null,
-        array $children = null
+        ?ParserNode $originNode = null,
+        ?NodeInterface $parent = null,
+        ?array $children = null
     ) {
         parent::__construct($value, $originNode, $parent, $children);
 

--- a/src/Phug/Formatter/Formatter/Element/KeywordElement.php
+++ b/src/Phug/Formatter/Formatter/Element/KeywordElement.php
@@ -27,9 +27,9 @@ class KeywordElement extends AbstractElement
     public function __construct(
         $name,
         $value,
-        ParserNode $originNode = null,
-        NodeInterface $parent = null,
-        array $children = null
+        ?ParserNode $originNode = null,
+        ?NodeInterface $parent = null,
+        ?array $children = null
     ) {
         parent::__construct($originNode, $parent, $children);
 

--- a/src/Phug/Formatter/Formatter/Element/MarkupElement.php
+++ b/src/Phug/Formatter/Formatter/Element/MarkupElement.php
@@ -32,10 +32,10 @@ class MarkupElement extends AbstractMarkupElement implements AttributesInterface
     public function __construct(
         $name,
         $autoClosed = false,
-        SplObjectStorage $attributes = null,
-        ParserNode $originNode = null,
-        NodeInterface $parent = null,
-        array $children = null
+        ?SplObjectStorage $attributes = null,
+        ?ParserNode $originNode = null,
+        ?NodeInterface $parent = null,
+        ?array $children = null
     ) {
         parent::__construct($originNode, $parent, $children);
 

--- a/src/Phug/Formatter/Formatter/Element/VariableElement.php
+++ b/src/Phug/Formatter/Formatter/Element/VariableElement.php
@@ -28,11 +28,11 @@ class VariableElement extends AbstractElement
      * @param array|null             $children
      */
     public function __construct(
-        CodeElement $variable = null,
-        ExpressionElement $expression = null,
-        ParserNode $originNode = null,
-        NodeInterface $parent = null,
-        array $children = null
+        ?CodeElement $variable = null,
+        ?ExpressionElement $expression = null,
+        ?ParserNode $originNode = null,
+        ?NodeInterface $parent = null,
+        ?array $children = null
     ) {
         parent::__construct($originNode, $parent, $children);
 

--- a/src/Phug/Formatter/Formatter/Event/FormatEvent.php
+++ b/src/Phug/Formatter/Formatter/Event/FormatEvent.php
@@ -37,7 +37,7 @@ class FormatEvent extends Event
     /**
      * @param ElementInterface $element
      */
-    public function setElement(ElementInterface $element = null)
+    public function setElement(?ElementInterface $element = null)
     {
         $this->element = $element;
     }

--- a/src/Phug/Formatter/Formatter/Format/HtmlFormat.php
+++ b/src/Phug/Formatter/Formatter/Format/HtmlFormat.php
@@ -11,7 +11,7 @@ class HtmlFormat extends XhtmlFormat
     const EXPLICIT_CLOSING_TAG = '<%s/>';
     const BOOLEAN_ATTRIBUTE_PATTERN = ' %s';
 
-    public function __construct(Formatter $formatter = null)
+    public function __construct(?Formatter $formatter = null)
     {
         parent::__construct($formatter);
 

--- a/src/Phug/Formatter/Formatter/Format/XhtmlFormat.php
+++ b/src/Phug/Formatter/Formatter/Format/XhtmlFormat.php
@@ -13,7 +13,7 @@ abstract class XhtmlFormat extends XmlFormat
     const DOCTYPE_LANGUAGE = 'html';
     const SELF_CLOSING_TAG = '<%s />';
 
-    public function __construct(Formatter $formatter = null)
+    public function __construct(?Formatter $formatter = null)
     {
         $this->setOptionsRecursive([
             'white_space_sensitive_tags' => [

--- a/src/Phug/Formatter/Formatter/Format/XmlFormat.php
+++ b/src/Phug/Formatter/Formatter/Format/XmlFormat.php
@@ -37,7 +37,7 @@ class XmlFormat extends AbstractFormat
     const BOOLEAN_ATTRIBUTE_PATTERN = ' %s="%s"';
     const BUFFER_VARIABLE = '$__value';
 
-    public function __construct(Formatter $formatter = null)
+    public function __construct(?Formatter $formatter = null)
     {
         parent::__construct($formatter);
 

--- a/src/Phug/Formatter/Formatter/FormatInterface.php
+++ b/src/Phug/Formatter/Formatter/FormatInterface.php
@@ -11,7 +11,7 @@ interface FormatInterface
 {
     const DEFAULT_VARIABLES_VARIABLE_NAME = 'pug_vars';
 
-    public function __construct(Formatter $formatter = null);
+    public function __construct(?Formatter $formatter = null);
 
     public function format($element);
 

--- a/src/Phug/Formatter/Formatter/Partial/PatternTrait.php
+++ b/src/Phug/Formatter/Formatter/Partial/PatternTrait.php
@@ -98,7 +98,7 @@ trait PatternTrait
      *
      * @return string
      */
-    public function exportHelper($name, array $arguments = null)
+    public function exportHelper($name, ?array $arguments = null)
     {
         $this->requireHelper($name);
 

--- a/src/Phug/Lexer/Lexer/AbstractToken.php
+++ b/src/Phug/Lexer/Lexer/AbstractToken.php
@@ -13,7 +13,7 @@ abstract class AbstractToken implements TokenInterface, HandleTokenInterface
     private $indentation;
     private $handled = false;
 
-    public function __construct(SourceLocationInterface $sourceLocation = null, $level = null, $indentation = null)
+    public function __construct(?SourceLocationInterface $sourceLocation = null, $level = null, $indentation = null)
     {
         $this->sourceLocation = $sourceLocation;
         $this->level = $level ?: 0;

--- a/src/Phug/Lexer/Lexer/Scanner/AttributeScanner.php
+++ b/src/Phug/Lexer/Lexer/Scanner/AttributeScanner.php
@@ -103,7 +103,7 @@ class AttributeScanner implements ScannerInterface
         $this->isTruncatedValue($expression);
     }
 
-    private function getAttributeValue(Reader $reader, array $chars = null)
+    private function getAttributeValue(Reader $reader, ?array $chars = null)
     {
         $chars = $chars ?: [
             ' ', "\t", "\n", ',', ')', '//',

--- a/src/Phug/Lexer/Lexer/Scanner/IndentationScanner.php
+++ b/src/Phug/Lexer/Lexer/Scanner/IndentationScanner.php
@@ -53,7 +53,7 @@ class IndentationScanner implements ScannerInterface
         return $indentChar;
     }
 
-    public function getIndentLevel(State $state, $maxLevel = INF, callable $getIndentChar = null)
+    public function getIndentLevel(State $state, $maxLevel = INF, ?callable $getIndentChar = null)
     {
         if ($maxLevel <= 0) {
             return 0;

--- a/src/Phug/Lexer/Lexer/TokenInterface.php
+++ b/src/Phug/Lexer/Lexer/TokenInterface.php
@@ -6,7 +6,7 @@ use Phug\Util\SourceLocationInterface;
 
 interface TokenInterface
 {
-    public function __construct(SourceLocationInterface $sourceLocation = null, $level = null, $indentation = null);
+    public function __construct(?SourceLocationInterface $sourceLocation = null, $level = null, $indentation = null);
 
     /**
      * @return SourceLocationInterface|null

--- a/src/Phug/Parser/Parser/Node.php
+++ b/src/Phug/Parser/Parser/Node.php
@@ -34,11 +34,11 @@ class Node extends AstNode implements NodeInterface
      * @param TokenInterface               $token          the token that created the node
      */
     public function __construct(
-        TokenInterface $token = null,
-        SourceLocationInterface $sourceLocation = null,
+        ?TokenInterface $token = null,
+        ?SourceLocationInterface $sourceLocation = null,
         $level = null,
-        NodeInterface $parent = null,
-        array $children = null
+        ?NodeInterface $parent = null,
+        ?array $children = null
     ) {
         parent::__construct($parent, $children);
 
@@ -77,7 +77,7 @@ class Node extends AstNode implements NodeInterface
      *
      * @return $this
      */
-    public function setOuterNode(NodeInterface $node = null)
+    public function setOuterNode(?NodeInterface $node = null)
     {
         $this->outerNode = $node;
 

--- a/src/Phug/Parser/Parser/State.php
+++ b/src/Phug/Parser/Parser/State.php
@@ -101,7 +101,7 @@ class State implements OptionInterface, EventManagerInterface
      */
     private $interpolationNodes;
 
-    public function __construct(Parser $parser, \Iterator $tokens, array $options = null)
+    public function __construct(Parser $parser, \Iterator $tokens, ?array $options = null)
     {
         $this->parser = $parser;
         $this->level = 0;
@@ -329,7 +329,7 @@ class State implements OptionInterface, EventManagerInterface
      *
      * @return $this
      */
-    public function handleToken(TokenInterface $token = null)
+    public function handleToken(?TokenInterface $token = null)
     {
         $token = $token ?: $this->getToken();
         $className = get_class($token);
@@ -534,7 +534,7 @@ class State implements OptionInterface, EventManagerInterface
      *
      * @return Node The newly created node
      */
-    public function createNode($className, TokenInterface $token = null)
+    public function createNode($className, ?TokenInterface $token = null)
     {
         if (!is_subclass_of($className, Node::class)) {
             throw new \InvalidArgumentException(
@@ -630,7 +630,7 @@ class State implements OptionInterface, EventManagerInterface
      *
      * @throws ParserException
      */
-    public function throwException($message, $code = 0, TokenInterface $relatedToken = null, $previous = null)
+    public function throwException($message, $code = 0, ?TokenInterface $relatedToken = null, $previous = null)
     {
         $lexer = $this->parser->getLexer();
         //This will basically check for a source location for this Node. The process is like:

--- a/src/Phug/Parser/ParserException.php
+++ b/src/Phug/Parser/ParserException.php
@@ -17,7 +17,7 @@ class ParserException extends LocatedException
         SourceLocation $location,
         $message = '',
         $code = 0,
-        TokenInterface $relatedToken = null,
+        ?TokenInterface $relatedToken = null,
         $previous = null
     ) {
         parent::__construct($location, $message, $code, $previous);

--- a/src/Phug/Phug/Phug/Partial/PluginEnablerTrait.php
+++ b/src/Phug/Phug/Phug/Partial/PluginEnablerTrait.php
@@ -15,7 +15,7 @@ trait PluginEnablerTrait
      *
      * @throws PhugException
      */
-    public static function enable(Renderer $renderer = null)
+    public static function enable(?Renderer $renderer = null)
     {
         if ($renderer) {
             static::activateOnRenderer($renderer);

--- a/src/Phug/Reader/Reader.php
+++ b/src/Phug/Reader/Reader.php
@@ -618,7 +618,7 @@ class Reader
      *
      * @return bool whether it could be or not.
      */
-    public function peekAlphaIdentifier(array $allowedChars = null)
+    public function peekAlphaIdentifier(?array $allowedChars = null)
     {
         $allowedChars = $allowedChars ?: ['_'];
 
@@ -632,7 +632,7 @@ class Reader
      *
      * @return bool whether it could be or not.
      */
-    public function peekIdentifier(array $allowedChars = null)
+    public function peekIdentifier(?array $allowedChars = null)
     {
         return $this->peekAlphaIdentifier($allowedChars) || $this->peekDigit();
     }
@@ -757,7 +757,7 @@ class Reader
      *
      * @return string|null the resulting string or null if none encountered.
      */
-    public function readString(array $escapeSequences = null, $raw = false)
+    public function readString(?array $escapeSequences = null, $raw = false)
     {
         if (!$this->peekQuote()) {
             return;
@@ -820,7 +820,7 @@ class Reader
      *
      * @return string|null the resulting expression or null, if none encountered.
      */
-    public function readExpression(array $breaks = null, array $brackets = null)
+    public function readExpression(?array $breaks = null, ?array $brackets = null)
     {
         if (!$this->hasLength()) {
             return;

--- a/src/Phug/Renderer/Renderer/Task/TasksGroup.php
+++ b/src/Phug/Renderer/Renderer/Task/TasksGroup.php
@@ -11,7 +11,7 @@ class TasksGroup
     protected $success = 0;
     protected $errorDetails = [];
 
-    public function __construct(Renderer $renderer = null)
+    public function __construct(?Renderer $renderer = null)
     {
         if ($renderer) {
             $this->renderer = $renderer;

--- a/src/Phug/Util/Util/SandBox.php
+++ b/src/Phug/Util/Util/SandBox.php
@@ -23,7 +23,7 @@ class SandBox
      */
     private $throwable;
 
-    public function __construct(callable $action, callable $errorInterceptor = null)
+    public function __construct(callable $action, ?callable $errorInterceptor = null)
     {
         set_error_handler($errorInterceptor ?: function ($number, $message, $file, $line) {
             if (error_reporting() & $number) {


### PR DESCRIPTION
I found a lot of warnings related to "Implicitly marking parameter XXX as nullable is deprecated, the explicit nullable type must be used instead" when trying to use Phug in PHP8.4.

```code
[Fri Mar  7 13:36:04 2025] PHP Deprecated:  Phug\Compiler::compileNode(): Implicitly marking parameter $parent as nullable is deprecated, the explicit nullable type must be used instead in /Users/user/Coding/.../vendor/phug/phug/src/Phug/Compiler/Compiler.php on line 502
...
```

The warnings have been corrected by marking explicitly as nullable those parameters that default to null.

The process was assisted by using [Rector](https://getrector.com/), with the following code:

```php
return Rector\Config\RectorConfig::configure()
    ->withPaths([__DIR__ . '/src'])
    ->withPhpVersion(Rector\ValueObject\PhpVersion::PHP_84)
    ->withRules([ Rector\Php84\Rector\Param\ExplicitNullableParamTypeRector::class, ]);
```

Fix #115